### PR TITLE
Update yaml files to match smarty.com docs

### DIFF
--- a/international-autocomplete-api.yaml
+++ b/international-autocomplete-api.yaml
@@ -11,7 +11,7 @@ info:
     name: Smarty Support
     email: support@smartystreets.com
 servers:
-  - url: 'https://international-autocomplete.api.smarty.com'
+  - url: 'https://international-autocomplete.api.smarty.com/v2/lookup[/{address_id}]'
 externalDocs:
   description: Extensive documentation for the International Address Autocomplete API
   url: 'https://www.smarty.com/docs/cloud/international-address-autocomplete-api'

--- a/international-autocomplete-api.yaml
+++ b/international-autocomplete-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: International Address Autocomplete
   version: '0.9'
-  description: "This API...\n\nReturns suggestions that are fully verified global addresses.\nUses fuzzy logic during searching to:\nAllow for missing directionals and street suffixes.\nAllow substitution of street suffixes and secondary designators. E.g., ST is accepted for AVE; APT is accepted for UNIT, etc.\nAllow full or partial spelling of street suffixes and secondary designators. E.g., ST can be spelled as STR or STREET and still match.\nFilters and preferences allow for multiple cities in a single country.\nAllows searching on alternate cities.\nSupports the following 137 countries:\nCountry\tISO3 Alpha-3\nCountry Code\nAlbania\tALB\nAlgeria\tDZA\nAndorra\tAND\nAngola\tAGO\nArgentina\tARG\nAruba\tABW\nAustralia\tAUS\nAustria\tAUT\nAzerbaijan\tAZE\nBahamas\tBHS\nBahrain\tBHR\nBarbados\tBRB\nBelarus\tBLR\nBelgium\tBEL\nBelize\tBLZ\nBenin\tBEN\nBermuda\tBMU\nBolivia\tBOL\nBosnia and Herzegovina\tBIH\nBotswana\tBWA\nBrazil\tBRA\nBrunei Darussalam\tBRN\nBulgaria\tBGR\nBurkina Faso\tBFA\nBurundi\tBDI\nCameroon\tCMR\nCanada\tCAN\nChile\tCHL\nChina\tCHN\nColombia\tCOL\nCongo-Brazzaville\tCOG\nCongo-Kinshasa\tCOD\nCosta-Rica\tCRI\nCroatia\tHRV\nCuba\tCUB\nCyprus\tCYP\nCzech Republic\tCZE\nDenmark\tDNK\nDominican Republic\tDOM\nEcuador\tECU\nEgypt\tEGY\nEl Salvador\tSLV\nEstonia\tEST\nFinland\tFIN\nFrance\tFRA\nGabon\tGAB\nGeorgia\tGEO\nGermany\tDEU\nGhana\tGHA\nGreece\tGRC\nGuatemala\tGTM\nGuyana\tGUY\nHonduras\tHND\nHong Kong\tHKG\nHungary\tHUN\nIceland\tISL\nIndia\tIND\nIndonesia\tIDN\nIraq\tIRQ\nIreland\tIRL\nIsrael\tISR\nItaly\tITA\nJamaica\tJAM\nJapan\tJPN\nJordan\tJOR\nKazakhstan\tKAZ\nKenya\tKEN\nKorea (South)\tKOR\nKosovo\tXKX\nKuwait\tKWT\nLatvia\tLVA\nLebanon\tLBN\nLesotho\tLSO\nLiechtenstein (Territory CHE)\tLIE\nLithuania\tLTU\nLuxembourg\tLUX\nMacau\tMAC\nMacedonia\tMKD\nMalawi\tMWI\nMalaysia\tMYS\nMali\tMLI\nMalta\tMLT\nMauritania\tMRT\nMauritius\tMUS\nMexico\tMEX\nMontenegro\tMNE\nMorocco\tMAR\nMozambique\tMOZ\nNamibia\tNAM\nNetherlands\tNLD\nNew Zealand\tNZL\nNicaragua\tNIC\nNiger\tNER\nNigeria\tNGA\nNorway\tNOR\nOman\tOMN\nPanama\tPAN\nParaguay\tPRY\nPeru\tPER\nPhilippines\tPHL\nPoland\tPOL\nPortugal\tPRT\nQatar\tQAT\nRomania\tROU\nRussia\tRUS\nRwanda\tRWA\nSaint Kitts and Nevis\tKNA\nSaudi Arabia\tSAU\nSenegal\tSEN\nSerbia\tSRB\nSingapore\tSGP\nSlovakia\tSVK\nSlovenia\tSVN\nSouth Africa\tZAF\nSpain\tESP\nSuriname\tSUR\nSwaziland\tSWZ\nSweden\tSWE\nSwitzerland, Liechtenstein\tCHE\nTaiwan\tTWN\nTajikistan\tTJK\nTanzania\tTZA\nThailand\tTHA\nTogo\tTGO\nTrinidad and Tobago\tTTO\nTunisia\tTUN\nTurkey\tTUR\nUganda\tUGA\nUkraine\tUKR\nUnited Arab Emirates\tARE\nUnited Kingdom\tGBR\nUruguay\tURY\nVenezuela\tVEN\nViet Nam\tVNM\nYemen\tYEM\nZambia\tZMB\nZimbabwe\tZWE\n"
+  description: "This API...\n\nReturns suggestions that are fully verified global addresses.\nUses fuzzy logic during searching to:\nAllow for missing directionals and street suffixes.\nAllow substitution of street suffixes and unit designators. E.g., ST is accepted for AVE; APT is accepted for UNIT, etc.\nAllow full or partial spelling of street suffixes and unit designators. E.g., ST can be spelled as STR or STREET and still match.\nFilters and preferences allow for multiple cities in a single country.\nNote: Effective with the adoption of the V2 version of International Address Autocomplete, lookup usage will be based on the final selection of an address rather than per keystroke.\n\nBy default, the character set returned will be the native set for that country. If any latin characters are provided in the input (excluding numerics), the latin set will be returned. Character sets include:\nCyrillic\nGreek\nHebrew\nKanji (Japanese)\nSimplified Chinese\nArabic\nThai\nHangul (Korean)\n\nSupports the following 242 countries: \nAfghanistan\tAFG\nAlbania\tALB\nAlgeria\tDZA\nAndorra\tAND\nAngola\tAGO\nAnguilla\tAIA\nAntarctica\tATA\nAntigua and Barbuda\tATG\nArgentina\tARG\nArmenia\tARM\nAruba\tABW\nAustralia\tAUS\nAustria\tAUT\nAzerbaijan\tAZE\nBahamas\tBHS\nBahrain\tBHR\nBangladesh\tBGD\nBarbados\tBRB\nBelarus\tBLR\nBelgium\tBEL\nBelize\tBLZ\nBenin\tBEN\nBermuda\tBMU\nBhutan\tBTN\nBolivia\tBOL\nBonaire, Sint Eustatius and Saba\tBES\nBosnia and Herzegovina\tBIH\nBotswana\tBWA\nBouvet Island\tBVT\nBrazil\tBRA\nBritish Indian Ocean Territory\tIOT\nBrunei Darussalam\tBRN\nBulgaria\tBGR\nBurkina Faso\tBFA\nBurundi\tBDI\nCambodia\tKHM\nCameroon\tCMR\nCanada\tCAN\nCabo Verde\tCPV\nCayman Islands\tCYM\nCentral African Republic\tCAF\nChad\tTCD\nChile\tCHL\nChina\tCHN\nChristmas Island\tCXR\nCocos (Keeling) Islands\tCCK\nColombia\tCOL\nComoros\tCOM\nCongo\tCOG\nDemocratic Republic of the Congo\tCOD\nCook Islands\tCOK\nCosta Rica\tCRI\nCroatia\tHRV\nCuba\tCUB\nCuraçao\tCUW\nCyprus\tCYP\nCzechia\tCZE\nIvory Coast\tCIV\nDenmark\tDNK\nDjibouti\tDJI\nDominica\tDMA\nDominican Republic\tDOM\nEcuador\tECU\nEgypt\tEGY\nEl Salvador\tSLV\nEquatorial Guinea\tGNQ\nEritrea\tERI\nEstonia\tEST\nEswatini\tSWZ\nEthiopia\tETH\nFalkland Islands\tFLK\nFaroe Islands\tFRO\nFiji\tFJI\nFinland\tFIN\nFrance\tFRA\nFrench Guiana\tGUF\nFrench Polynesia\tPYF\nFrench Southern Territories\tATF\nGabon\tGAB\nGambia\tGMB\nGeorgia\tGEO\nGermany\tDEU\nGhana\tGHA\nGibraltar\tGIB\nGreece\tGRC\nGreenland\tGRL\nGrenada\tGRD\nGuadeloupe\tGLP\nGuatemala\tGTM\nGuernsey\tGGY\nGuinea\tGIN\nGuinea-Bissau\tGNB\nGuyana\tGUY\nHaiti\tHTI\nHeard Island and McDonald Islands\tHMD\nHoly See\tVAT\nHonduras\tHND\nHong Kong\tHKG\nHungary\tHUN\nIceland\tISL\nIndia\tIND\nIndonesia\tIDN\nIslamic Republic of Iran\tIRN\nIraq\tIRQ\nIreland\tIRL\nIsle of Man\tIMN\nIsrael\tISR\nItaly\tITA\nJamaica\tJAM\nJapan\tJPN\nJersey\tJEY\nJordan\tJOR\nKazakhstan\tKAZ\nKenya\tKEN\nKiribati\tKIR\nDemocratic People's Republic of Korea (North Korea)\tPRK\nRepublic of Korea\tKOR\nKosovo\tXKX\nKuwait\tKWT\nKyrgyzstan\tKGZ\nLao People's Democratic Republic\tLAO\nLatvia\tLVA\nLebanon\tLBN\nLesotho\tLSO\nLiberia\tLBR\nLibya\tLBY\nLiechtenstein\tLIE\nLithuania\tLTU\nLuxembourg\tLUX\nMacao\tMAC\nRepublic of North Macedonia\tMKD\nMadagascar\tMDG\nMalawi\tMWI\nMalaysia\tMYS\nMaldives\tMDV\nMali\tMLI\nMalta\tMLT\nMartinique\tMTQ\nMauritania\tMRT\nMauritius\tMUS\nMayotte\tMYT\nMexico\tMEX\nFederated States of Micronesia\tFSM\nRepublic of Moldova\tMDA\nMonaco\tMCO\nMongolia\tMNG\nMontenegro\tMNE\nMontserrat\tMSR\nMorocco\tMAR\nMozambique\tMOZ\nMyanmar\tMMR\nNamibia\tNAM\nNauru\tNRU\nNepal\tNPL\nNetherlands\tNLD\nNew Caledonia\tNCL\nNew Zealand\tNZL\nNicaragua\tNIC\nNiger\tNER\nNigeria\tNGA\nNiue\tNIU\nNorfolk Island\tNFK\nNorway\tNOR\nOman\tOMN\nPakistan\tPAK\nPalau\tPLW\nState of Palestine\tPSE\nPanama\tPAN\nPapua New Guinea\tPNG\nParaguay\tPRY\nPeru\tPER\nPhilippines\tPHL\nPitcairn\tPCN\nPoland\tPOL\nPortugal\tPRT\nQatar\tQAT\nSouth Sudan\tSSD\nRomania\tROU\nRussian Federation\tRUS\nRwanda\tRWA\nRéunion\tREU\nSaint Barthélemy\tBLM\nSaint Helena, Ascension and Tristan da Cunha\tSHN\nSaint Kitts and Nevis\tKNA\nSaint Lucia\tLCA\nSaint Martin\tMAF\nSaint Pierre and Miquelon\tSPM\nSaint Vincent and the Grenadines\tVCT\nSamoa\tWSM\nSan Marino\tSMR\nSao Tome and Principe\tSTP\nSaudi Arabia\tSAU\nSenegal\tSEN\nSerbia\tSRB\nSeychelles\tSYC\nSierra Leone\tSLE\nSingapore\tSGP\nSint Maarten (Dutch)\tSXM\nSlovakia\tSVK\nSlovenia\tSVN\nSolomon Islands\tSLB\nSomalia\tSOM\nSouth Africa\tZAF\nSouth Georgia and the South Sandwich Islands\tSGS\nSpain\tESP\nSri Lanka\tLKA\nSudan\tSDN\nSuriname\tSUR\nSvalbard and Jan Mayen Islands\tSJM\nSweden\tSWE\nSwitzerland\tCHE\nSyrian Arab Republic\tSYR\nTaiwan\tTWN\nTajikistan\tTJK\nUnited Republic of Tanzania\tTZA\nThailand\tTHA\nTimor-Leste\tTLS\nTogo\tTGO\nTokelau\tTKL\nTonga\tTON\nTrinidad and Tobago\tTTO\nTunisia\tTUN\nTürkiye (Turkey)\tTUR\nTurkmenistan\tTKM\nTurks and Caicos Islands\tTCA\nTuvalu\tTUV\nUganda\tUGA\nUkraine\tUKR\nUnited Arab Emirates\tARE\nUnited Kingdom\tGBR\nUruguay\tURY\nUzbekistan\tUZB\nVanuatu\tVUT\nBolivarian Republic of Venezuela\tVEN\nViet Nam\tVNM\nBritish Virgin Islands\tVGB\nWallis and Futuna\tWLF\nWestern Sahara\tESH\nYemen\tYEM\nZambia\tZMB\nZimbabwe\tZWE\nÅland Islands\tALA\n"
   termsOfService: 'https://smartystreets.com/legal/terms-of-service'
   license:
     url: 'https://www.smarty.com/legal/terms-of-service'
@@ -48,36 +48,22 @@ paths:
         - $ref: '#/components/parameters/geolocation'
         - $ref: '#/components/parameters/include_only_locality'
         - $ref: '#/components/parameters/include_only_postal_code'
-        - $ref: '#/components/parameters/latitude'
-        - $ref: '#/components/parameters/longitude'
 components:
   schemas:
     candidate:
       title: candidate
       type: object
       properties:
-        street:
+        entries:
+          type: integer
+        address_text:
           type: string
-        locality:
-          type: string
-        administrative_area:
-          type: string
-        administrative_area_short:
-          type: string
-        administrative_area_long:
-          type: string
-        postal_code:
-          type: string
-        country_iso3:
+        address_id:
           type: string
       examples:
-        - street: 1-123 Main St
-          locality: Fredericton
-          administrative_area: NB
-          administrative_area_short: NB
-          administrative_area_long: New Brunswick
-          postal_code: E3A 1C7
-          country_iso3: CAN
+        - entries: 12
+          address_text: 123 Main St Winnipeg, MB, R3C
+          address_id: PD4DPC8DOjE4AzI9Uig2MTE2Lzo4UjI+NjEgLCtSTk1M
   securitySchemes:
     auth-id:
       type: apiKey
@@ -121,14 +107,14 @@ components:
       required: true
       schema:
         type: string
-      description: 'The ISO3 Alpha-3 country code where the desired address is located. Only uppercase values are allowed. See supported country codes (https://www.smarty.com/docs/cloud/international-address-autocomplete-api#supported-country-codes).   Maximum length is 3 bytes.'
+      description: 'The ISO3 Alpha-3 country code where the desired address is located. Only uppercase values are allowed. See supported country codes (https://www.smarty.com/docs/cloud/international-address-autocomplete-api#supported-country-codes). Maximum length is 3 bytes.'
     search:
       name: search
       in: query
       required: true
       schema:
         type: string
-      description: The part of the address that has already been typed. Maximum length is 128 bytes.
+      description: 'The part of the address that has already been typed. Maximum character count is 32 characters. Required when address ID is not specified in the URL.'
     max_results:
       name: max_results
       in: query
@@ -156,25 +142,11 @@ components:
       required: false
       schema:
         type: string
-      description: 'Limit the results to only the locality provided. A locality is a significant population center (i.e. city, town, or village). Example: Paris'
+      description: 'Limit the results to only the locality provided. A locality is a significant population center (i.e. city, town, or village). When this parameter is used, include_only_postal_code cannot be used. Separate multiple values with a comma. Example: Paris,Versailles'
     include_only_postal_code:
       name: include_only_postal_code
       in: query
       required: false
       schema:
         type: string
-      description: 'Limit the results to only the postal code provided. When this parameter is used, no include_only_administrative_area and/or include_only_locality parameters can be used.  Example: 29200'
-    latitude:
-      name: latitude
-      in: query
-      required: false
-      schema:
-        type: string
-      description: 'Limit the results to the surrounding area specified by latitude and longitude. See also distance  Example: -2.0234 This must be used with the longitude parameter.'
-    longitude:
-      name: longitude
-      in: query
-      required: false
-      schema:
-        type: string
-      description: 'Limit the results to the surrounding area specified by latitude and longitude. See also distance  Example: 44.0234 This must be used with the latitude parameter.'
+      description: 'Limit the results to only the postal codes provided. When this parameter is used, include_only_locality cannot be used. Separate multiple values with a comma. Example: 29200,29201'

--- a/international-postal-code-api.yaml
+++ b/international-postal-code-api.yaml
@@ -1,0 +1,181 @@
+openapi: 3.1.0
+info:
+  title: International-Postal-Code-API
+  description: |
+    Utilize the SmartyStreets RESTful API to search for a Country and locality OR administrative area OR postal code and access more relevant information than you could possibly need. 
+  termsOfService: 'https://smartystreets.com/legal/terms-of-service'
+  contact:
+    url: 'https://www.smarty.com/contact/support'
+    email: support@smarty.com
+    name: Smarty Support
+  license:
+    url: 'https://www.smarty.com/legal/terms-of-service'
+    name: Smarty License
+  version: 4.1.3
+servers:
+  - url: 'https://international-postal-code.api.smarty.com'
+externalDocs:
+  description: Extensive documentation for the International-Postal-Code-API
+  url: 'https://smartystreets.com/docs/cloud/international-postal-code-api'
+paths:
+  /lookup:
+    get:
+      tags:
+        - lookup
+      summary: Search country and locality/administrative area/postal code
+      operationId: lookup-get
+      description: |
+        To send one (and only one) input to the API, simply encode the field names from the table below along with their corresponding values as query string parameters in the URL of your request. Here's an example that uses locality, administrative_area, postal_code, and country fields:
+        ```bash
+          curl -v 'https://international-postal-code.api.smarty.com/lookup?
+            	auth-id=YOUR+AUTH-ID+HERE&
+            	auth-token=YOUR+AUTH-TOKEN+HERE&
+            
+            	locality=Sao+Paulo&
+            	administrative_area=SP&
+            	postal_code=02516-040&
+            	country=Brazil'
+        ```
+        Please note that all query string parameter values must be url-encoded (spaces become + or %20, for example) to ensure that the data is transferred correctly. A common mistake we see is a non-encoded pound sign (#) like in an apartment number (# 409). This character, when properly encoded in a URL, becomes %23. When not encoded this character functions as the fragment identifier, which is ignored by our API servers.
+      parameters:
+        - $ref: '#/components/parameters/Host'
+        - $ref: '#/components/parameters/input_id'
+        - $ref: '#/components/parameters/country'
+        - $ref: '#/components/parameters/locality'
+        - $ref: '#/components/parameters/administrative_area'
+        - $ref: '#/components/parameters/postal_code'
+        - $ref: '#/components/parameters/license'
+      responses:
+        '200':
+          description: 'OK(success!), The response body will be a JSON array containing zero or more matches for the input provided with the request. The structure of the response is the same for both GET and POST requests.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Root'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '402':
+          $ref: '#/components/responses/402'
+        '422':
+          $ref: '#/components/responses/422'
+        '429':
+          $ref: '#/components/responses/429'
+        '504':
+          $ref: '#/components/responses/504'
+security:
+  - auth_id: []
+    auth_token: []
+  - website_key: []
+tags:
+  - name: lookup
+    description: Search country and locality/administrative area/postal code
+components:
+  parameters:
+    Host:
+      name: Host
+      in: header
+      required: true
+      schema:
+        type: string
+      description: 'The Host request header field specifies the internet host and port number of the resource being requested. EX: Host: international-postal-code.api.smarty.com'
+    input_id:
+      name: input_id
+      in: query
+      example: 8675309
+      description: 'A unique identifier for this address used in your application; this field will be copied to the output'
+      schema:
+        type: string
+    country:
+      name: country
+      in: query
+      required: true
+      description: 'This must be entered with every address. Country Name or ISO classification (ISO-3, ISO-2, ISO-N). Address validation will fail if this is missing. (e.g. Brazil, BRA, BR, or 076)'
+      schema:
+        type: string
+    locality:
+      name: locality
+      in: query
+      example: Paris
+      description: 'The city name'
+    administrative_area:
+      name: administrative_area
+      in: query
+      description: 'The state or province name or abbreviation. (e.g. Alberta or AB)
+    postal_code:
+      name: postal_code
+      in: query
+      description: 'The postal code (e.g. T4B 5M7). You may submit a postal code preefix to widen your search. (e.g. T4B 5)'
+    license:
+      name: license
+      in: query
+      description: 'The license or licenses (comma-separated) to use for this lookup. Valid values can be found in the account dashboard under the appropriate subscription. If multiple licenses are specified, they are considered in left-to-right order.'
+  schemas:
+    Root:
+      title: Successful response
+      type: object
+      description: 'OK (success!): The response body will be a JSON array containing 0 to 1000 items for the input provided with the request. Since there is no paging capability to return more than the maximum, you will need to refine your search to return fewer results. Transliteration is not available in this API. All results will be returned using the Latin character set.'
+      properties:
+        input_id:
+          type: string
+          description: 'A unique identifier generated by you for this address for use within your application. The output will be identical to the value you provided in the request input_id.'
+        administrative_area:
+          type: string
+          description: 'The most common administrative division within a country (ex. province in Canada)'
+        super_administrative_area:
+          type: string
+          description: 'The largest administrative division within a country (ex. region in France)'
+        sub_administrative_area:
+          type: string
+          description: 'The smallest administrative division within a country (ex. county in Germany)'
+        locality:
+          type: string
+          description: 'Within a country, this is the most common population center (ex. city in Chile)'
+        dependent_locality:
+          type: string
+          description: 'If there is additional information about the locality, it will be here (ex. neighborhood in Turkey)'
+        dependent_locality_name:
+          type: string
+          description: "If the dependent_locality has a name, you'll find it here. (ex. the dependent_locality 'Dong Cheng Qu' is named 'Dong Cheng')"
+        double_dependent_locality:
+          type: string
+          description: "If there is additional information about the dependent_locality, you'll find it here. (ex. village in the United Kingdom)"
+        postal_code:
+          type: string
+          description: 'The complete postal code for the delivery point (ex. V6G1V9 in Canada)'
+        postal_code_extra:
+          type: string
+          description: 'Secondary postal code information (ex. 3425 in the United States)'
+        country_iso_3:
+          type: string
+          description: 'The ISO 3166-1 alpha-3 country code'
+  securitySchemes:
+    auth_id:
+      type: apiKey
+      name: auth-id
+      in: query
+    auth_token:
+      type: apiKey
+      name: auth-token
+      in: query
+    website_key:
+      type: apiKey
+      name: key
+      in: query
+  responses:
+    '400':
+      description: 'Bad Request (Malformed Payload): The request body of a POST request contained no lookups or contained malformed JSON.'
+    '401':
+      description: 'Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.'
+    '402':
+      description: 'Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.'
+    '422':
+      description: 'Unprocessable Entity: A GET request lacked required fields.'
+    '429':
+      description: |
+        'Too Many Requests: When using public embedded key authentication, we restrict the number of requests coming from a given source over too short of a time. If you use embedded key authentication, you can avoid this error by adding your IP address as an authorized host for the embedded key in question.'
+        'OR'
+        'Too Many Requests: Too many requests with exactly the same input values were submitted within too short a period. This status code conveys that the input was not processed in order to prevent runaway charges caused by such conditions as a misbehaving (infinite) loop that's sending the same record over and over to the API. You're welcome.'
+    '504':
+      description: 'Gateway Timeout: Our own upstream data provider did not repond in a timely fashion, and the request failed. A serious, yet rare occurrence indeed.'

--- a/international-street-api.yaml
+++ b/international-street-api.yaml
@@ -34,8 +34,6 @@ paths:
           $ref: '#/components/responses/401'
         '402':
           $ref: '#/components/responses/402'
-        '403':
-          $ref: '#/components/responses/403'
         '422':
           $ref: '#/components/responses/422'
         '429':
@@ -74,6 +72,7 @@ paths:
         - $ref: '#/components/parameters/administrative_area'
         - $ref: '#/components/parameters/postal_code'
         - $ref: '#/components/parameters/license'
+        - $ref: '#/components/parameters/features'
 components:
   schemas:
     Root:
@@ -111,6 +110,9 @@ components:
         country_iso_3:
           type: string
           description: 'The ISO 3166-1 alpha-3 country code. See https://www.smarty.com/docs/cloud/international-street-api#countries for details.'
+        attention:
+          type: string
+          description: 'The name of the recipient, firm, or company at this address. This is the same value as the organization field.'
         administrative_area:
           type: string
           description: |-
@@ -314,10 +316,22 @@ components:
       properties:
         latitude:
           type: number
-          description: 'The horizontal component used for geographic positioning; it is the angle between 0° (the equator) and ±90° (north or south) at the poles measured in decimal degrees. It is the first value in an ordered pair of latitude, longitude. A negative number denotes a location south of the equator; a positive number is north. Combining lat/long values enables you to pinpoint addresses on a map.'
+          description: 'The horizontal component used for geographic positioning; ***based on the WGS84 coordinate system*** it is the angle between 0° (the equator) and ±90° (north or south) at the poles measured in decimal degrees. It is the first value in an ordered pair of latitude, longitude. A negative number denotes a location south of the equator; a positive number is north. Combining lat/long values enables you to pinpoint addresses on a map.'
         longitude:
           type: number
-          description: 'The vertical component used for geographic positioning; it is the angle between 0° (the Prime Meridian) and ±180° (westward or eastward) measured in decimal degrees. It is the second number in an ordered pair of (latitude, longitude). A negative number indicates a location west of Greenwich, England; a positive number east. Combining lat/long values enables you to pinpoint addresses on a map.'
+          description: 'The vertical component used for geographic positioning; ***based on the WGS84 coordinate system*** it is the angle between 0° (the Prime Meridian) and ±180° (westward or eastward) measured in decimal degrees. It is the second number in an ordered pair of (latitude, longitude). A negative number indicates a location west of Greenwich, England; a positive number east. Combining lat/long values enables you to pinpoint addresses on a map.'
+        geocode_classificiation:
+          type: string
+          description: |-
+            Provides additional information about the returned geocode.
+
+            single-point - Returned a single matching geocode
+
+            multiple-point-average - The output address matched several geocodes. To provide a single result, we calculated and returned the average coordinate of those points.
+
+            interpolated - Returned a geocode that was interpolated from a range of addresses near the returned address.
+
+            This data will only be returned when the feature is requested.
         geocode_precision:
           type: string
           description: |-
@@ -331,9 +345,9 @@ components:
 
             Thoroughfare — Geocode is accurate down to the thoroughfare (i.e., street).
 
-            Premise — Geocode is accurate down to a range of addresses on the specified street (i.e., building, block level or street segment).
+            Premise — Geocode is accurate to the actual delivery point (i.e., house, mailbox, or apartment).
 
-            DeliveryPoint — Geocode is accurate to the actual delivery point (i.e., house, mailbox or apartment).
+            * Must be enabled by sending the geocode-precision-enhanced feature flag. Only available in CAN and GBR.
         max_geocode_precision:
           type: string
           description: Indicates the best geocode_precision available for the input country.
@@ -355,7 +369,17 @@ components:
             Address 3: postal_code locality
             For native languages that do not use spaces between words, the corresponding component fields will also not have spaces between them.
 
-            The address_format field will not be present for US addresses. Here's some additional info on the composition of US addresses.
+            This field may not be present in the following cases:
+            1. When we could not understand the input sufficiently to generate a value.
+            2. For US addresses it willl never be present.
+        occupant_use:
+          type: string
+          description: |-
+            (Canada, Australia, Belgium, Great Britain) Indicates if the property is Residential or Commercial.
+
+            This data will be returned only when the feature is requested.
+
+            Possible values: "residential","commercial","residential,commercial"
     Analysis:
       title: Analysis
       type: object
@@ -367,7 +391,7 @@ components:
 
             None — Not verified. The output fields will contain the input data.
 
-            Partial — Verification only at the level indicated by address_precision. (Better input might result in a better match.)
+            Partial — Verification only at the level indicated by address_precision. For some countries whose maximum precision level is less than DeliveryPoint or Premise, this may be the best verification status you may receive. Otherwise, better input might result in a better match.
 
             Ambiguous — Multiple matching addresses found. Each candidate address will have its own precision level. A common "ambiguous" scenario is that the output will contain two versions of the same address — one with an organization name and one without.
 
@@ -394,12 +418,6 @@ components:
         changes:
           $ref: '#/components/schemas/Changes'
           description: 'Contains a collection of address components paired with values which specify the difference between corresponding input/lookup and output/candidate data. See the explanation of possible Changes here: https://www.smarty.com/docs/cloud/international-street-api#changes'
-        organization:
-          type: string
-          description: 'If present, the degree of change to the name of the recipient, firm, or company at this address.'
-        address1-12:
-          type: string
-          description: 'If present, these fields show the degree of change to each of the address lines.'
         components:
           $ref: '#/components/schemas/Components'
     Changes:
@@ -460,8 +478,6 @@ components:
       description: 'Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.'
     '402':
       description: 'Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.'
-    '403':
-      description: 'Forbidden: Because the international service is currently in a limited release phase, only approved accounts may access the service. Please contact us for your account to be granted access.'
     '422':
       description: 'Unprocessable Entity: A GET request lacked required fields.'
     '429':
@@ -579,3 +595,10 @@ components:
       schema:
         type: string
       description: 'The license or licenses (comma separated) to use for this lookup. Valid values can be found in the account dashboard under the appropriate subscription. If multiple licenses are specified, they are considered in left to right order. We recommend that each request explicitly specify a license value. For more information see License Selection.'
+    features:
+      name: features
+      in: query
+      required: false
+      schema:
+        type: string
+      description: 'A comma-separated list of features. These may require a special plan that allows the feature to be used. Examples:\noccupant-use: Return the occupant_use metadata field\ngeocode-classification: Return the geocode_classification metadata field if geocode=true\ngeocode-precision-enhanced: Enable the PostalCode return value in geocode_precision'

--- a/us-autocomplete-api.yaml
+++ b/us-autocomplete-api.yaml
@@ -2,7 +2,15 @@ openapi: 3.1.0
 info:
   title: US-Autocomplete-API
   description: |
-    Utilize the SmartyStreets RESTful API if you want us to suggest some addresses to verify for you, you obviously still have the final say for what you end up verifying though. 
+    'Returns suggestions that are fully verified USPS addresses.'
+    'Uses fuzzy logic during searching to:'
+      - 'Allow for missing directionals and street suffixes'
+      - 'Allow substitution of street suffixes and secondary designators (E.g. ST is accepted for AVE; APT is accepted for UNIT, etc.)'
+      - 'Allow full or partial spelling of street suffixes and secondary designators (E.g. ST can be spelled as STR or STREET and still match)'
+    'Filters and preferences allow for multiple cities in a single state.'
+    'Provides filter keywords for commons state collections such as allstates.'
+    'ZIP Codes are valid filter and preference values.'
+    'Allows searching on alternate cities.'
   termsOfService: 'https://smartystreets.com/legal/terms-of-service'
   license:
     url: 'https://www.smarty.com/legal/terms-of-service'
@@ -16,18 +24,18 @@ servers:
   - url: 'https://us-autocomplete.api.smarty.com'
 externalDocs:
   description: Extensive documentation for the US Autocomplete Pro API
-  url: https://www.smarty.com/docs/cloud/us-autocomplete-pro-api
+  url: 'https://www.smarty.com/docs/cloud/us-autocomplete-pro-api'
 paths:
-  /suggest:
+  /lookup:
     get:
-      operationId: get-suggest
+      operationId: get-lookup
       tags:
-        - suggest
+        - lookup
       summary: Get Address Suggestions and Verify
       parameters:
-        - $ref: '#/components/parameters/prefix'
         - $ref: '#/components/parameters/Host'
         - $ref: '#/components/parameters/Referer'
+        - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/max_results'
         - $ref: '#/components/parameters/include_only_cities'
         - $ref: '#/components/parameters/include_only_states'
@@ -57,7 +65,6 @@ paths:
           description: 'Unprocessable Entity (Unsuitable parameters): Returns errors describing what needs to be corrected.'
         '429':
           description: 'Too Many Requests: When using public embedded key authentication, we restrict the number of requests coming from a given source over too short of a time. You can avoid this error by adding your IP address as an authorized host for the embedded key in question.'
-      description: ''
 security:
   - auth-id: []
     auth-token: []
@@ -67,31 +74,6 @@ tags:
     description: Search Street Addresses
 components:
   parameters:
-    prefix:
-      name: search
-      in: query
-      description: '*Example: 123 mai* The part of the address that has alread been typed. Maximum length is 128 bytes.'
-      schema:
-        type: string
-      required: true
-    include_only_cities:
-      name: include_only_cities
-      in: query
-      description: 'Limit the results to only those cities and states listed, as well as those in include_only_states. Example: DENVER,AURORA,CO;OMAHA,NE '
-      schema:
-        type: string
-    include_only_states:
-      name: include_only_states
-      in: query
-      description: 'Limit the results to only those states listed, as well as those listed in include_only_cities. Examples: UT;ID;MT or CONTIGUOUS or ALLSTATES'
-      schema:
-        type: string
-    prefer_ratio:
-      name: prefer_ratio
-      in: query
-      description: 'Specifies the percentage of address suggestions that should be preferred and will appear at the top of the suggestion list. Expressed as an integer value, range [0, 100]. Default: 100'
-      schema:
-        type: integer
     Host:
       name: Host
       in: header
@@ -106,6 +88,13 @@ components:
       schema:
         type: string
       description: 'The Referer is required when an embedded key is used for authentication. Its value is in the form of a URL, where the host component must match a host value assigned to your embedded key. Note: Some HTTP clients such as a browser or programming language HTTP libraries will add this header automatically. However some interfaces such as cURL do not, so you may need to add it manually. Ex: Referer: https://mycoolwebsite.com'
+    search:
+      name: search
+      in: query
+      description: 'Required. The part of the address that has already been typed. Maximum character count is 32 characters.'
+      schema:
+        type: string
+      required: true
     max_results:
       name: max_results
       in: query
@@ -113,6 +102,18 @@ components:
       schema:
         type: integer
       description: 'Maximum number of address suggestions to return; range [1, 10]. Default Value: 10'
+    include_only_cities:
+      name: include_only_cities
+      in: query
+      description: 'Limit the results to only those cities and states listed, as well as those in include_only_states. IMPORTANT: This field must contain a state after the list of cities as shown in the example. Another important note is that you should NOT list a state mentioned within this field in the include_only_states field as it takes precedence over this field. Example: DENVER,AURORA,CO;OMAHA,NE '
+      schema:
+        type: string
+    include_only_states:
+      name: include_only_states
+      in: query
+      description: 'Limit the results to only those states listed, as well as those listed in include_only_cities. IMPORTANT: If a state is mentioned in the include_only_cities field, you should NOT include that same state in this field as it will take precedence. Examples: UT;ID;MT or CONTIGUOUS or ALLSTATES'
+      schema:
+        type: string
     include_only_zip_codes:
       name: include_only_zip_codes
       in: query
@@ -148,6 +149,12 @@ components:
       schema:
         type: string
       description: 'Display suggestions with the listed ZIP Codes at the top of the suggestion list. When this parameter is used, no other _cities or _states parameters can be used.  Note: When using this parameter, the prefer_geolocation parameter must NOT be set to city. '
+    prefer_ratio:
+      name: prefer_ratio
+      in: query
+      description: 'Specifies the percentage of address suggestions that should be preferred and will appear at the top of the suggestion list. Expressed as an integer value, range [0, 100]. Default: 100'
+      schema:
+        type: integer
     prefer_geolocation:
       name: prefer_geolocation
       in: query
@@ -161,13 +168,13 @@ components:
       required: false
       schema:
         type: string
-      description: Used by UI components to request a list of secondaries (up to 100) for the specified address. See Secondary Number Expansion at Smarty.com for usage information.
+      description: 'Used by UI components to request a list of secondaries (up to 100) for the specified address. See Secondary Number Expansion at Smarty.com for usage information.'
     source:
       name: source
       in: query
       schema:
         type: string
-      description: 'Include results from alternate data sources. Allowed values are: all - will include non-postal addresses in the results postal - will limit the results to postal addresses only  If this parameter is used, an additional field named source will be returned for each result, which is either postal for postal addresses, or other if the address is from an alternate data source. Default: postal'
+      description: 'Include results from alternate data sources. Allowed values are: all - will include non-postal addresses in the results; postal - will limit the results to postal addresses only  If this parameter is used, an additional field named source will be returned for each result, which is either postal for postal addresses, or other if the address is from an alternate data source. Default: postal'
   schemas:
     '200':
       title: Successful response
@@ -186,6 +193,7 @@ components:
           example: 123 Main Rd
         secondary:
           type: string
+          example: Unit 1
         city:
           type: string
           example: Abbot

--- a/us-enrichment-api.yaml
+++ b/us-enrichment-api.yaml
@@ -356,8 +356,7 @@ components:
       in: query
       schema:
         type: string
-        default: 128
-      description: 'A comma-separated list of features. These may require a special plan that allows the feature to be used. EXAMPLE: Feature Value: financial; Description: Return the financial_history attribute. This is applicalbe only to property requests.'
+      description: 'A comma-separated list of features. These may require a special plan that allows the feature to be used. EXAMPLE: Feature Value: financial; Description: Return the financial_history attribute. This is applicalbe only to property requests. Default: 128'
     freeform:
       name: freeform
       in: query

--- a/us-enrichment-api.yaml
+++ b/us-enrichment-api.yaml
@@ -17,12 +17,12 @@ externalDocs:
   description: "Extensive documentation for the US Address Enrichment API"
   url: https://www.smarty.com/docs/cloud/us-address-enrichment-api
 paths:
-  '/lookup/{smartykey}/property/principal':
+  '/lookup/{smartykey}/property':
     get:
       tags:
         - us-enrichment
-      summary: Property Principal Lookup by Smartykey
-      description: 'Contains all property data attributes including tax assessor and recorder data. Recorder data will be last available financial transaction for the property.'
+      summary: Property Lookup by Smartykey
+      description: 'Contains all property data attributes including tax assessor and recorder data. Recorder data will be last available financial transaction for the property. When requesting the financial feature, the result will contain historical financial data pertaining to the property and property owner.'
       security:
         - auth-id: [ ]
           auth-token: [ ]
@@ -33,9 +33,12 @@ paths:
         - $ref: '#/components/parameters/etag'
         - $ref: '#/components/parameters/include'
         - $ref: '#/components/parameters/exclude'
+        - $ref: '#/components/parameters/features'
       responses:
         '200':
-          $ref: '#/components/responses/PropertyPrincipalResponseSmartyKey'
+          $ref: '#/components/responses/PropertyResponseSmartyKey'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -48,12 +51,12 @@ paths:
           $ref: '#/components/responses/UnprocessableContent'
         '429':
           $ref: '#/components/responses/TooManyRequests'
-  '/lookup/search/property/principal':
+  '/lookup/search/property':
     get:
       tags:
         - us-enrichment
-      summary: Property Principal Lookup by Search Fields
-      description: 'Contains all property data attributes including tax assessor and recorder data. Recorder data will be last available financial transaction for the property.'
+      summary: Property Lookup by Search Fields
+      description: 'Contains all property data attributes including tax assessor and recorder data. Recorder data will be last available financial transaction for the property. When requesting the financial feature, the result will contain historical financial data pertaining to the property and property owner.'
       security:
         - auth-id: [ ]
           auth-token: [ ]
@@ -63,6 +66,7 @@ paths:
         - $ref: '#/components/parameters/etag'
         - $ref: '#/components/parameters/include'
         - $ref: '#/components/parameters/exclude'
+        - $ref: '#/components/parameters/features'
         - $ref: '#/components/parameters/freeform'
         - $ref: '#/components/parameters/street'
         - $ref: '#/components/parameters/city'
@@ -70,73 +74,9 @@ paths:
         - $ref: '#/components/parameters/zipcode'
       responses:
         '200':
-          $ref: '#/components/responses/PropertyPrincipalResponseSearch'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '402':
-          $ref: '#/components/responses/PaymentRequired'
-        '413':
-          $ref: '#/components/responses/RequestTooLarge'
-        '422':
-          $ref: '#/components/responses/UnprocessableContent'
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-  '/lookup/{smartykey}/property/financial':
-    get:
-      tags:
-        - us-enrichment
-      summary: Property Financial Lookup by Smartykey
-      description: "Dataset that contains historical financial data attributes pertaining to the property and property owner."
-      security:
-        - auth-id: []
-          auth-token: []
-        - embedded-key: []
-      parameters:
-        - $ref: '#/components/parameters/smartykey'
-        - $ref: '#/components/parameters/content-type'
-        - $ref: '#/components/parameters/etag'
-        - $ref: '#/components/parameters/include'
-        - $ref: '#/components/parameters/exclude'
-      responses:
-        '200':
-          $ref: '#/components/responses/PropertyFinancialResponseSmartyKey'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '402':
-          $ref: '#/components/responses/PaymentRequired'
-        '413':
-          $ref: '#/components/responses/RequestTooLarge'
-        '422':
-          $ref: '#/components/responses/UnprocessableContent'
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-  '/lookup/search/property/financial':
-    get:
-      tags:
-        - us-enrichment
-      summary: Property Financial Lookup by Search Fields
-      description: "Dataset that contains historical financial data attributes pertaining to the property and property owner."
-      security:
-        - auth-id: [ ]
-          auth-token: [ ]
-        - embedded-key: [ ]
-      parameters:
-        - $ref: '#/components/parameters/content-type'
-        - $ref: '#/components/parameters/etag'
-        - $ref: '#/components/parameters/include'
-        - $ref: '#/components/parameters/exclude'
-        - $ref: '#/components/parameters/freeform'
-        - $ref: '#/components/parameters/street'
-        - $ref: '#/components/parameters/city'
-        - $ref: '#/components/parameters/state'
-        - $ref: '#/components/parameters/zipcode'
-      responses:
-        '200':
-          $ref: '#/components/responses/PropertyFinancialResponseSearch'
+          $ref: '#/components/responses/PropertyResponseSearch'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -153,8 +93,12 @@ paths:
     get:
       tags:
         - us-enrichment
-      summary: US GeoReference Data Lookup by Smartykey
-      description: 'The GeoReference Data product provides useful geographic data for geocoded addresses, such as census block id. Request legacy data, such as the 2010 and 2020 census, by specifying a data subset of 2010 or 2020. For example: To return 2010 census data, specify geo-reference/2010. To request the latest census information available, simply specify geo-reference with no trailing subset. The census version will be returned in the data_set_version property in the response.'
+      summary: US Census Block and Tract Lookup by Smartykey
+      description: 'The Census Block and Tract Data product provides useful geographic data for geocoded addresses, such as census block id. Request legacy data, such as the 2010 and 2020 census, by specifying a data subset of 2010 or 2020. For example: To return 2010 census data, specify geo-reference/2010. To request the latest census information available, simply specify geo-reference with no trailing subset. The census version will be returned in the data_set_version property in the response.'
+      security:
+        - auth-id: [ ]
+          auth-token: [ ]
+        - embedded-key: [ ]
       parameters:
       - $ref: '#/components/parameters/smartykey'
       - $ref: '#/components/parameters/dataset'
@@ -162,9 +106,12 @@ paths:
       - $ref: '#/components/parameters/etag'
       - $ref: '#/components/parameters/include'
       - $ref: '#/components/parameters/exclude'
+      - $ref: '#/components/parameters/features'
       responses:
         '200':
-          $ref: '#/components/responses/GeoReferenceResponseSmartyKey'
+          $ref: '#/components/responses/CensusBlockAndTractResponseSmartyKey'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -181,14 +128,19 @@ paths:
     get:
       tags:
         - us-enrichment
-      summary: US GeoReference Data Lookup by Search Fields
-      description: 'The GeoReference Data product provides useful geographic data for geocoded addresses, such as census block id. Request legacy data, such as the 2010 and 2020 census, by specifying a data subset of 2010 or 2020. For example: To return 2010 census data, specify geo-reference/2010. To request the latest census information available, simply specify geo-reference with no trailing subset. The census version will be returned in the data_set_version property in the response.'
+      summary: US Census Block and Tract Data Lookup by Search Fields
+      description: 'The Census Block and Tract Data product provides useful geographic data for geocoded addresses, such as census block id. Request legacy data, such as the 2010 and 2020 census, by specifying a data subset of 2010 or 2020. For example: To return 2010 census data, specify geo-reference/2010. To request the latest census information available, simply specify geo-reference with no trailing subset. The census version will be returned in the data_set_version property in the response.'
+      security:
+        - auth-id: [ ]
+          auth-token: [ ]
+        - embedded-key: [ ]
       parameters:
         - $ref: '#/components/parameters/dataset'
         - $ref: '#/components/parameters/content-type'
         - $ref: '#/components/parameters/etag'
         - $ref: '#/components/parameters/include'
         - $ref: '#/components/parameters/exclude'
+        - $ref: '#/components/parameters/features'
         - $ref: '#/components/parameters/freeform'
         - $ref: '#/components/parameters/street'
         - $ref: '#/components/parameters/city'
@@ -196,73 +148,9 @@ paths:
         - $ref: '#/components/parameters/zipcode'
       responses:
         '200':
-          $ref: '#/components/responses/GeoReferenceResponseSearch'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '402':
-          $ref: '#/components/responses/PaymentRequired'
-        '413':
-          $ref: '#/components/responses/RequestTooLarge'
-        '422':
-          $ref: '#/components/responses/UnprocessableContent'
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-  '/lookup/{smartykey}/risk':
-    get:
-      tags:
-        - us-enrichment
-      summary: Risk Lookup by Smartykey
-      description: "The risk data product returns FEMA NRI (National Risk Index) data associated with an address or SmartyKey. Fields with zero values, or near zero values (to the fourth decimal place) are not returned and are considered to not be significant."
-      security:
-        - auth-id: [ ]
-          auth-token: [ ]
-        - embedded-key: [ ]
-      parameters:
-        - $ref: '#/components/parameters/smartykey'
-        - $ref: '#/components/parameters/content-type'
-        - $ref: '#/components/parameters/etag'
-        - $ref: '#/components/parameters/include'
-        - $ref: '#/components/parameters/exclude'
-      responses:
-        '200':
-          $ref: '#/components/responses/RiskResponseSmartyKey'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '402':
-          $ref: '#/components/responses/PaymentRequired'
-        '413':
-          $ref: '#/components/responses/RequestTooLarge'
-        '422':
-          $ref: '#/components/responses/UnprocessableContent'
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-  '/lookup/search/risk':
-    get:
-      tags:
-        - us-enrichment
-      summary: Risk Lookup by Search Fields
-      description: "The risk data product returns FEMA NRI (National Risk Index) data associated with an address or SmartyKey. Fields with zero values, or near zero values (to the fourth decimal place) are not returned and are considered to not be significant."
-      security:
-        - auth-id: [ ]
-          auth-token: [ ]
-        - embedded-key: [ ]
-      parameters:
-        - $ref: '#/components/parameters/content-type'
-        - $ref: '#/components/parameters/etag'
-        - $ref: '#/components/parameters/include'
-        - $ref: '#/components/parameters/exclude'
-        - $ref: '#/components/parameters/freeform'
-        - $ref: '#/components/parameters/street'
-        - $ref: '#/components/parameters/city'
-        - $ref: '#/components/parameters/state'
-        - $ref: '#/components/parameters/zipcode'
-      responses:
-        '200':
-          $ref: '#/components/responses/RiskResponseSearch'
+          $ref: '#/components/responses/CensusBlockAndTractResponseSearch'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -281,15 +169,22 @@ paths:
         - us-enrichment
       summary: US Secondary Data Lookup by Smartykey
       description: 'The secondary data product returns all secondaries and aliases associated with a SmartyKey. The SmartyKey can be that of the root address, any of the aliases, or any of the secondaries. Each will return the same related data.'
+      security:
+        - auth-id: [ ]
+          auth-token: [ ]
+        - embedded-key: [ ]
       parameters:
         - $ref: '#/components/parameters/smartykey'
         - $ref: '#/components/parameters/content-type'
         - $ref: '#/components/parameters/etag'
         - $ref: '#/components/parameters/include'
         - $ref: '#/components/parameters/exclude'
+        - $ref: '#/components/parameters/features'
       responses:
         '200':
           $ref: '#/components/responses/SecondaryResponseSmartyKey'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -308,11 +203,16 @@ paths:
         - us-enrichment
       summary: US Secondary Data Lookup by Search Fields
       description: 'The secondary data product returns all secondaries and aliases associated with a SmartyKey. Each will return the same related data.'
+      security:
+        - auth-id: [ ]
+          auth-token: [ ]
+        - embedded-key: [ ]
       parameters:
         - $ref: '#/components/parameters/content-type'
         - $ref: '#/components/parameters/etag'
         - $ref: '#/components/parameters/include'
         - $ref: '#/components/parameters/exclude'
+        - $ref: '#/components/parameters/features'
         - $ref: '#/components/parameters/freeform'
         - $ref: '#/components/parameters/street'
         - $ref: '#/components/parameters/city'
@@ -321,6 +221,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SecondaryResponseSearch'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -339,15 +241,22 @@ paths:
         - us-enrichment
       summary: US Secondary Data Lookup by Smartykey
       description: 'The secondary data product returns all secondaries and aliases associated with a SmartyKey. The SmartyKey can be that of the root address, any of the aliases, or any of the secondaries. Each will return the same related data. The count subset only returns the number of secondaries associated with the SmartyKey. Detailed data is not returned.'
+      security:
+        - auth-id: [ ]
+          auth-token: [ ]
+        - embedded-key: [ ]
       parameters:
         - $ref: '#/components/parameters/smartykey'
         - $ref: '#/components/parameters/content-type'
         - $ref: '#/components/parameters/etag'
         - $ref: '#/components/parameters/include'
         - $ref: '#/components/parameters/exclude'
+        - $ref: '#/components/parameters/features'
       responses:
         '200':
           $ref: '#/components/responses/SecondaryCountResponseSmartyKey'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -366,11 +275,16 @@ paths:
         - us-enrichment
       summary: US Secondary Data Lookup by Search Fields
       description: 'The secondary data product returns all secondaries and aliases associated with a SmartyKey. Each will return the same related data. The count subset only returns the number of secondaries associated with the SmartyKey. Detailed data is not returned.'
+      security:
+        - auth-id: [ ]
+          auth-token: [ ]
+        - embedded-key: [ ]
       parameters:
         - $ref: '#/components/parameters/content-type'
         - $ref: '#/components/parameters/etag'
         - $ref: '#/components/parameters/include'
         - $ref: '#/components/parameters/exclude'
+        - $ref: '#/components/parameters/features'
         - $ref: '#/components/parameters/freeform'
         - $ref: '#/components/parameters/street'
         - $ref: '#/components/parameters/city'
@@ -379,6 +293,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SecondaryCountResponseSearch'
+        '304':
+          $ref: '#/components/responses/NotModified
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -435,6 +351,13 @@ components:
       schema:
         type: string
       description: 'List of attributes that are not allowed to be included in the response. This list can include Group names and Attribute names separated by commas. All values must be lowercase.'
+    features:
+      name: features:
+      in: query
+      schema:
+        type: string
+        default: 128
+      description: 'A comma-separated list of features. These may require a special plan that allows the feature to be used. EXAMPLE: Feature Value: financial; Description: Return the financial_history attribute. This is applicalbe only to property requests.'
     freeform:
       name: freeform
       in: query
@@ -466,7 +389,7 @@ components:
         type: string
       description: 'The ZIP Code. You may also need to provide values for other component search fields.'
   schemas:
-    PropertyPrincipalResponseSmartyKey:
+    PropertyResponseSmartyKey:
       properties:
         smarty_key:
           type: string
@@ -475,10 +398,13 @@ components:
         data_subset_name:
           type: string
         attributes:
-          allOf:
-            - $ref: '#/components/schemas/GroupStructuralAttributes'
-            - $ref: '#/components/schemas/GroupLocationAttributes'
-    PropertyPrincipalResponseSearch:
+          oneOf:
+            allOf:
+              - $ref: '#/components/schemas/GroupStructuralAttributes'
+              - $ref: '#/components/schemas/GroupLocationAttributes'
+            allOf:
+              - $ref: '#/components/schemas/GroupFinancialAttributes'
+    PropertyResponseSearch:
       properties:
         smarty_key:
           type: string
@@ -489,34 +415,13 @@ components:
         matched_address:
          $ref: '#/components/schemas/MatchedAddress'
         attributes:
-          allOf:
-            - $ref: '#/components/schemas/GroupStructuralAttributes'
-            - $ref: '#/components/schemas/GroupLocationAttributes'
-    PropertyFinancialResponseSmartyKey:
-      properties:
-        smarty_key:
-          type: string
-        data_set_name:
-          type: string
-        data_subset_name:
-          type: string
-        attributes:
-          allOf:
-            - $ref: '#/components/schemas/GroupFinancialAttributes'
-    PropertyFinancialResponseSearch:
-      properties:
-        smarty_key:
-          type: string
-        data_set_name:
-          type: string
-        data_subset_name:
-          type: string
-        matched_address:
-          $ref: '#/components/schemas/MatchedAddress'
-        attributes:
-          allOf:
-            - $ref: '#/components/schemas/GroupFinancialAttributes'
-    GeoReferenceResponseSmartyKey:
+          oneOf:
+            allOf:
+              - $ref: '#/components/schemas/GroupStructuralAttributes'
+              - $ref: '#/components/schemas/GroupLocationAttributes'
+            allOf:
+              - $ref: '#/components/schemas/GroupFinancialAttributes'
+    CensusBlockAndTractResponseSmartyKey:
       properties:
         smarty_key:
           type: string
@@ -537,7 +442,7 @@ components:
               $ref: '#/components/schemas/CoreBasedStatArea'
             place:
               $ref: '#/components/schemas/Place'
-    GeoReferenceResponseSearch:
+    CensusBlockAndTractResponseSearch:
       properties:
         smarty_key:
           type: string
@@ -560,26 +465,6 @@ components:
               $ref: '#/components/schemas/CoreBasedStatArea'
             place:
               $ref: '#/components/schemas/Place'
-    RiskResponseSmartyKey:
-      properties:
-        smarty_key:
-          type: string
-        data_set_name:
-          type: string
-        attributes:
-          allOf:
-            - $ref: '#/components/schemas/RiskFields'
-    RiskResponseSearch:
-      properties:
-        smarty_key:
-          type: string
-        data_set_name:
-          type: string
-        matched_address:
-          $ref: '#/components/schemas/MatchedAddress'
-        attributes:
-          allOf:
-            - $ref: '#/components/schemas/RiskFields'
     SecondaryResponseSmartyKey:
       type: object
       properties:
@@ -682,7 +567,7 @@ components:
           description: 'Indicates if the Census Place is incorporated or unincorporated.'
     GroupFinancialAttributes:
       type: object
-      description: "Financial attributes in the Principal Dataset records."
+      description: "Financial attributes in the Financial Dataset records."
       properties:
         assessed_improvement_percent:
           type: string
@@ -1508,1405 +1393,6 @@ components:
           type: string
         zipcode:
           type: string
-    RiskFields:
-      type: object
-      description: "The risk data fields are based on the FEMA National Risk Index (NRI) data definitions. Fields with zero values, or near zero values (to the fourth decimal place) are not returned and are considered to not be significant."
-      properties:
-        AGRIVALUE:
-          type: string
-          description: "Agriculture Value ($)"
-        ALR_NPCTL:
-          type: string
-          description: "Expected Annual Loss Rate - National Percentile - Composite"
-        ALR_VALA:
-          type: string
-          description: "Expected Annual Loss Rate - Agriculture - Composite"
-        ALR_VALB:
-          type: string
-          description: "Expected Annual Loss Rate - Building - Composite"
-        ALR_VALP:
-          type: string
-          description: "Expected Annual Loss Rate - Population - Composite"
-        ALR_VRA_NPCTL:
-          type: string
-          description: "Social Vulnerability and Community Resilience Adjusted Expected Annual Loss Rate - National Percentile - Composite"
-        AREA:
-          type: string
-          description: "Area (sq mi)"
-        AVLN_AFREQ:
-          type: string
-          description: "Avalanche - Annualized Frequency"
-        AVLN_ALRB:
-          type: string
-          description: "Avalanche - Expected Annual Loss Rate - Building"
-        AVLN_ALRP:
-          type: string
-          description: "Avalanche - Expected Annual Loss Rate - Population"
-        AVLN_ALR_NPCTL:
-          type: string
-          description: "Avalanche - Expected Annual Loss Rate - National Percentile"
-        AVLN_EALB:
-          type: string
-          description: "Avalanche - Expected Annual Loss - Building Value"
-        AVLN_EALP:
-          type: string
-          description: "Avalanche - Expected Annual Loss - Population"
-        AVLN_EALPE:
-          type: string
-          description: "Avalanche - Expected Annual Loss - Population Equivalence"
-        AVLN_EALR:
-          type: string
-          description: "Avalanche - Expected Annual Loss Rating"
-        AVLN_EALS:
-          type: string
-          description: "Avalanche - Expected Annual Loss Score"
-        AVLN_EALT:
-          type: string
-          description: "Avalanche - Expected Annual Loss - Total"
-        AVLN_EVNTS:
-          type: string
-          description: "Avalanche - Number of Events"
-        AVLN_EXPB:
-          type: string
-          description: "Avalanche - Exposure - Building Value"
-        AVLN_EXPP:
-          type: string
-          description: "Avalanche - Exposure - Population"
-        AVLN_EXPPE:
-          type: string
-          description: "Avalanche - Exposure - Population Equivalence"
-        AVLN_EXPT:
-          type: string
-          description: "Avalanche - Exposure - Total"
-        AVLN_EXP_AREA:
-          type: string
-          description: "Avalanche - Exposure - Impacted Area (sq mi)"
-        AVLN_HLRB:
-          type: string
-          description: "Avalanche - Historic Loss Ratio - Buildings"
-        AVLN_HLRP:
-          type: string
-          description: "Avalanche - Historic Loss Ratio - Population"
-        AVLN_HLRR:
-          type: string
-          description: "Avalanche - Historic Loss Ratio - Total Rating"
-        AVLN_RISKR:
-          type: string
-          description: "Avalanche - Hazard Type Risk Index Rating"
-        AVLN_RISKS:
-          type: string
-          description: "Avalanche - Hazard Type Risk Index Score"
-        AVLN_RISKV:
-          type: string
-          description: "Avalanche - Hazard Type Risk Index Value"
-        BUILDVALUE:
-          type: string
-          description: "Building Value ($)"
-        CFLD_AFREQ:
-          type: string
-          description: "Coastal Flooding - Annualized Frequency"
-        CFLD_ALRB:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss Rate - Building"
-        CFLD_ALRP:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss Rate - Population"
-        CFLD_ALR_NPCTL:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss Rate - National Percentile"
-        CFLD_EALB:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss - Building Value"
-        CFLD_EALP:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss - Population"
-        CFLD_EALPE:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss - Population Equivalence"
-        CFLD_EALR:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss Rating"
-        CFLD_EALS:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss Score"
-        CFLD_EALT:
-          type: string
-          description: "Coastal Flooding - Expected Annual Loss - Total"
-        CFLD_EVNTS:
-          type: string
-          description: "Coastal Flooding - Number of Events"
-        CFLD_EXPB:
-          type: string
-          description: "Coastal Flooding - Exposure - Building Value"
-        CFLD_EXPP:
-          type: string
-          description: "Coastal Flooding - Exposure - Population"
-        CFLD_EXPPE:
-          type: string
-          description: "Coastal Flooding - Exposure - Population Equivalence"
-        CFLD_EXPT:
-          type: string
-          description: "Coastal Flooding - Exposure - Total"
-        CFLD_EXP_AREA:
-          type: string
-          description: "Coastal Flooding - Exposure - Impacted Area (sq mi)"
-        CFLD_HLRB:
-          type: string
-          description: "Coastal Flooding - Historic Loss Ratio - Buildings"
-        CFLD_HLRP:
-          type: string
-          description: "Coastal Flooding - Historic Loss Ratio - Population"
-        CFLD_HLRR:
-          type: string
-          description: "Coastal Flooding - Historic Loss Ratio - Total Rating"
-        CFLD_RISKR:
-          type: string
-          description: "Coastal Flooding - Hazard Type Risk Index Rating"
-        CFLD_RISKS:
-          type: string
-          description: "Coastal Flooding - Hazard Type Risk Index Score"
-        CFLD_RISKV:
-          type: string
-          description: "Coastal Flooding - Hazard Type Risk Index Value"
-        COUNTY:
-          type: string
-          description: "County Name"
-        COUNTYFIPS:
-          type: string
-          description: "County FIPS Code"
-        COUNTYTYPE:
-          type: string
-          description: "County Type"
-        CRF_VALUE:
-          type: string
-          description: "Community Risk Factor - Value"
-        CWAV_AFREQ:
-          type: string
-          description: "Cold Wave - Annualized Frequency"
-        CWAV_ALRA:
-          type: string
-          description: "Cold Wave - Expected Annual Loss Rate - Agriculture"
-        CWAV_ALRB:
-          type: string
-          description: "Cold Wave - Expected Annual Loss Rate - Building"
-        CWAV_ALRP:
-          type: string
-          description: "Cold Wave - Expected Annual Loss Rate - Population"
-        CWAV_ALR_NPCTL:
-          type: string
-          description: "Cold Wave - Expected Annual Loss Rate - National Percentile"
-        CWAV_EALA:
-          type: string
-          description: "Cold Wave - Expected Annual Loss - Agriculture Value"
-        CWAV_EALB:
-          type: string
-          description: "Cold Wave - Expected Annual Loss - Building Value"
-        CWAV_EALP:
-          type: string
-          description: "Cold Wave - Expected Annual Loss - Population"
-        CWAV_EALPE:
-          type: string
-          description: "Cold Wave - Expected Annual Loss - Population Equivalence"
-        CWAV_EALR:
-          type: string
-          description: "Cold Wave - Expected Annual Loss Rating"
-        CWAV_EALS:
-          type: string
-          description: "Cold Wave - Expected Annual Loss Score"
-        CWAV_EALT:
-          type: string
-          description: "Cold Wave - Expected Annual Loss - Total"
-        CWAV_EVNTS:
-          type: string
-          description: "Cold Wave - Number of Events"
-        CWAV_EXPA:
-          type: string
-          description: "Cold Wave - Exposure - Agriculture Value"
-        CWAV_EXPB:
-          type: string
-          description: "Cold Wave - Exposure - Building Value"
-        CWAV_EXPP:
-          type: string
-          description: "Cold Wave - Exposure - Population"
-        CWAV_EXPPE:
-          type: string
-          description: "Cold Wave - Exposure - Population Equivalence"
-        CWAV_EXPT:
-          type: string
-          description: "Cold Wave - Exposure - Total"
-        CWAV_EXP_AREA:
-          type: string
-          description: "Cold Wave - Exposure - Impacted Area (sq mi)"
-        CWAV_HLRA:
-          type: string
-          description: "Cold Wave - Historic Loss Ratio - Agriculture"
-        CWAV_HLRB:
-          type: string
-          description: "Cold Wave - Historic Loss Ratio - Buildings"
-        CWAV_HLRP:
-          type: string
-          description: "Cold Wave - Historic Loss Ratio - Population"
-        CWAV_HLRR:
-          type: string
-          description: "Cold Wave - Historic Loss Ratio - Total Rating"
-        CWAV_RISKR:
-          type: string
-          description: "Cold Wave - Hazard Type Risk Index Rating"
-        CWAV_RISKS:
-          type: string
-          description: "Cold Wave - Hazard Type Risk Index Score"
-        CWAV_RISKV:
-          type: string
-          description: "Cold Wave - Hazard Type Risk Index Value"
-        DRGT_AFREQ:
-          type: string
-          description: "Drought - Annualized Frequency"
-        DRGT_ALRA:
-          type: string
-          description: "Drought - Expected Annual Loss Rate - Agriculture"
-        DRGT_ALR_NPCTL:
-          type: string
-          description: "Drought - Expected Annual Loss Rate - National Percentile"
-        DRGT_EALA:
-          type: string
-          description: "Drought - Expected Annual Loss - Agriculture Value"
-        DRGT_EALR:
-          type: string
-          description: "Drought - Expected Annual Loss Rating"
-        DRGT_EALS:
-          type: string
-          description: "Drought - Expected Annual Loss Score"
-        DRGT_EALT:
-          type: string
-          description: "Drought - Expected Annual Loss - Total"
-        DRGT_EVNTS:
-          type: string
-          description: "Drought - Number of Events"
-        DRGT_EXPA:
-          type: string
-          description: "Drought - Exposure - Agriculture Value"
-        DRGT_EXPT:
-          type: string
-          description: "Drought - Exposure - Total"
-        DRGT_EXP_AREA:
-          type: string
-          description: "Drought - Exposure - Impacted Area (sq mi)"
-        DRGT_HLRA:
-          type: string
-          description: "Drought - Historic Loss Ratio - Agriculture"
-        DRGT_HLRR:
-          type: string
-          description: "Drought - Historic Loss Ratio - Total Rating"
-        DRGT_RISKR:
-          type: string
-          description: "Drought - Hazard Type Risk Index Rating"
-        DRGT_RISKS:
-          type: string
-          description: "Drought - Hazard Type Risk Index Score"
-        DRGT_RISKV:
-          type: string
-          description: "Drought - Hazard Type Risk Index Value"
-        EAL_RATNG:
-          type: string
-          description: "Expected Annual Loss - Rating - Composite"
-        EAL_SCORE:
-          type: string
-          description: "Expected Annual Loss - Score - Composite"
-        EAL_SPCTL:
-          type: string
-          description: "Expected Annual Loss - State Percentile - Composite"
-        EAL_VALA:
-          type: string
-          description: "Expected Annual Loss - Agriculture Value - Composite"
-        EAL_VALB:
-          type: string
-          description: "Expected Annual Loss - Building Value - Composite"
-        EAL_VALP:
-          type: string
-          description: "Expected Annual Loss - Population - Composite"
-        EAL_VALPE:
-          type: string
-          description: "Expected Annual Loss - Population Equivalence - Composite"
-        EAL_VALT:
-          type: string
-          description: "Expected Annual Loss - Total - Composite"
-        ERQK_AFREQ:
-          type: string
-          description: "Earthquake - Annualized Frequency"
-        ERQK_ALRB:
-          type: string
-          description: "Earthquake - Expected Annual Loss Rate - Building"
-        ERQK_ALRP:
-          type: string
-          description: "Earthquake - Expected Annual Loss Rate - Population"
-        ERQK_ALR_NPCTL:
-          type: string
-          description: "Earthquake - Expected Annual Loss Rate - National Percentile"
-        ERQK_EALB:
-          type: string
-          description: "Earthquake - Expected Annual Loss - Building Value"
-        ERQK_EALP:
-          type: string
-          description: "Earthquake - Expected Annual Loss - Population"
-        ERQK_EALPE:
-          type: string
-          description: "Earthquake - Expected Annual Loss - Population Equivalence"
-        ERQK_EALR:
-          type: string
-          description: "Earthquake - Expected Annual Loss Rating"
-        ERQK_EALS:
-          type: string
-          description: "Earthquake - Expected Annual Loss Score"
-        ERQK_EALT:
-          type: string
-          description: "Earthquake - Expected Annual Loss - Total"
-        ERQK_EVNTS:
-          type: string
-          description: "Earthquake - Number of Events"
-        ERQK_EXPB:
-          type: string
-          description: "Earthquake - Exposure - Building Value"
-        ERQK_EXPP:
-          type: string
-          description: "Earthquake - Exposure - Population"
-        ERQK_EXPPE:
-          type: string
-          description: "Earthquake - Exposure - Population Equivalence"
-        ERQK_EXPT:
-          type: string
-          description: "Earthquake - Exposure - Total"
-        ERQK_EXP_AREA:
-          type: string
-          description: "Earthquake - Exposure - Impacted Area (sq mi)"
-        ERQK_HLRB:
-          type: string
-          description: "Earthquake - Historic Loss Ratio - Buildings"
-        ERQK_HLRP:
-          type: string
-          description: "Earthquake - Historic Loss Ratio - Population"
-        ERQK_HLRR:
-          type: string
-          description: "Earthquake - Historic Loss Ratio - Total Rating"
-        ERQK_RISKR:
-          type: string
-          description: "Earthquake - Hazard Type Risk Index Rating"
-        ERQK_RISKS:
-          type: string
-          description: "Earthquake - Hazard Type Risk Index Score"
-        ERQK_RISKV:
-          type: string
-          description: "Earthquake - Hazard Type Risk Index Value"
-        HAIL_AFREQ:
-          type: string
-          description: "Hail - Annualized Frequency"
-        HAIL_ALRA:
-          type: string
-          description: "Hail - Expected Annual Loss Rate - Agriculture"
-        HAIL_ALRB:
-          type: string
-          description: "Hail - Expected Annual Loss Rate - Building"
-        HAIL_ALRP:
-          type: string
-          description: "Hail - Expected Annual Loss Rate - Population"
-        HAIL_ALR_NPCTL:
-          type: string
-          description: "Hail - Expected Annual Loss Rate - National Percentile"
-        HAIL_EALA:
-          type: string
-          description: "Hail - Expected Annual Loss - Agriculture Value"
-        HAIL_EALB:
-          type: string
-          description: "Hail - Expected Annual Loss - Building Value"
-        HAIL_EALP:
-          type: string
-          description: "Hail - Expected Annual Loss - Population"
-        HAIL_EALPE:
-          type: string
-          description: "Hail - Expected Annual Loss - Population Equivalence"
-        HAIL_EALR:
-          type: string
-          description: "Hail - Expected Annual Loss Rating"
-        HAIL_EALS:
-          type: string
-          description: "Hail - Expected Annual Loss Score"
-        HAIL_EALT:
-          type: string
-          description: "Hail - Expected Annual Loss - Total"
-        HAIL_EVNTS:
-          type: string
-          description: "Hail - Number of Events"
-        HAIL_EXPA:
-          type: string
-          description: "Hail - Exposure - Agriculture Value"
-        HAIL_EXPB:
-          type: string
-          description: "Hail - Exposure - Building Value"
-        HAIL_EXPP:
-          type: string
-          description: "Hail - Exposure - Population"
-        HAIL_EXPPE:
-          type: string
-          description: "Hail - Exposure - Population Equivalence"
-        HAIL_EXPT:
-          type: string
-          description: "Hail - Exposure - Total"
-        HAIL_EXP_AREA:
-          type: string
-          description: "Hail - Exposure - Impacted Area (sq mi)"
-        HAIL_HLRA:
-          type: string
-          description: "Hail - Historic Loss Ratio - Agriculture"
-        HAIL_HLRB:
-          type: string
-          description: "Hail - Historic Loss Ratio - Buildings"
-        HAIL_HLRP:
-          type: string
-          description: "Hail - Historic Loss Ratio - Population"
-        HAIL_HLRR:
-          type: string
-          description: "Hail - Historic Loss Ratio - Total Rating"
-        HAIL_RISKR:
-          type: string
-          description: "Hail - Hazard Type Risk Index Rating"
-        HAIL_RISKS:
-          type: string
-          description: "Hail - Hazard Type Risk Index Score"
-        HAIL_RISKV:
-          type: string
-          description: "Hail - Hazard Type Risk Index Value"
-        HRCN_AFREQ:
-          type: string
-          description: "Hurricane - Annualized Frequency"
-        HRCN_ALRA:
-          type: string
-          description: "Hurricane - Expected Annual Loss Rate - Agriculture"
-        HRCN_ALRB:
-          type: string
-          description: "Hurricane - Expected Annual Loss Rate - Building"
-        HRCN_ALRP:
-          type: string
-          description: "Hurricane - Expected Annual Loss Rate - Population"
-        HRCN_ALR_NPCTL:
-          type: string
-          description: "Hurricane - Expected Annual Loss Rate - National Percentile"
-        HRCN_EALA:
-          type: string
-          description: "Hurricane - Expected Annual Loss - Agriculture Value"
-        HRCN_EALB:
-          type: string
-          description: "Hurricane - Expected Annual Loss - Building Value"
-        HRCN_EALP:
-          type: string
-          description: "Hurricane - Expected Annual Loss - Population"
-        HRCN_EALPE:
-          type: string
-          description: "Hurricane - Expected Annual Loss - Population Equivalence"
-        HRCN_EALR:
-          type: string
-          description: "Hurricane - Expected Annual Loss Rating"
-        HRCN_EALS:
-          type: string
-          description: "Hurricane - Expected Annual Loss Score"
-        HRCN_EALT:
-          type: string
-          description: "Hurricane - Expected Annual Loss - Total"
-        HRCN_EVNTS:
-          type: string
-          description: "Hurricane - Number of Events"
-        HRCN_EXPA:
-          type: string
-          description: "Hurricane - Exposure - Agriculture Value"
-        HRCN_EXPB:
-          type: string
-          description: "Hurricane - Exposure - Building Value"
-        HRCN_EXPP:
-          type: string
-          description: "Hurricane - Exposure - Population"
-        HRCN_EXPPE:
-          type: string
-          description: "Hurricane - Exposure - Population Equivalence"
-        HRCN_EXPT:
-          type: string
-          description: "Hurricane - Exposure - Total"
-        HRCN_EXP_AREA:
-          type: string
-          description: "Hurricane - Exposure - Impacted Area (sq mi)"
-        HRCN_HLRA:
-          type: string
-          description: "Hurricane - Historic Loss Ratio - Agriculture"
-        HRCN_HLRB:
-          type: string
-          description: "Hurricane - Historic Loss Ratio - Buildings"
-        HRCN_HLRP:
-          type: string
-          description: "Hurricane - Historic Loss Ratio - Population"
-        HRCN_HLRR:
-          type: string
-          description: "Hurricane - Historic Loss Ratio - Total Rating"
-        HRCN_RISKR:
-          type: string
-          description: "Hurricane - Hazard Type Risk Index Rating"
-        HRCN_RISKS:
-          type: string
-          description: "Hurricane - Hazard Type Risk Index Score"
-        HRCN_RISKV:
-          type: string
-          description: "Hurricane - Hazard Type Risk Index Value"
-        HWAV_AFREQ:
-          type: string
-          description: "Heat Wave - Annualized Frequency"
-        HWAV_ALRA:
-          type: string
-          description: "Heat Wave - Expected Annual Loss Rate - Agriculture"
-        HWAV_ALRB:
-          type: string
-          description: "Heat Wave - Expected Annual Loss Rate - Building"
-        HWAV_ALRP:
-          type: string
-          description: "Heat Wave - Expected Annual Loss Rate - Population"
-        HWAV_ALR_NPCTL:
-          type: string
-          description: "Heat Wave - Expected Annual Loss Rate - National Percentile"
-        HWAV_EALA:
-          type: string
-          description: "Heat Wave - Expected Annual Loss - Agriculture Value"
-        HWAV_EALB:
-          type: string
-          description: "Heat Wave - Expected Annual Loss - Building Value"
-        HWAV_EALP:
-          type: string
-          description: "Heat Wave - Expected Annual Loss - Population"
-        HWAV_EALPE:
-          type: string
-          description: "Heat Wave - Expected Annual Loss - Population Equivalence"
-        HWAV_EALR:
-          type: string
-          description: "Heat Wave - Expected Annual Loss Rating"
-        HWAV_EALS:
-          type: string
-          description: "Heat Wave - Expected Annual Loss Score"
-        HWAV_EALT:
-          type: string
-          description: "Heat Wave - Expected Annual Loss - Total"
-        HWAV_EVNTS:
-          type: string
-          description: "Heat Wave - Number of Events"
-        HWAV_EXPA:
-          type: string
-          description: "Heat Wave - Exposure - Agriculture Value"
-        HWAV_EXPB:
-          type: string
-          description: "Heat Wave - Exposure - Building Value"
-        HWAV_EXPP:
-          type: string
-          description: "Heat Wave - Exposure - Population"
-        HWAV_EXPPE:
-          type: string
-          description: "Heat Wave - Exposure - Population Equivalence"
-        HWAV_EXPT:
-          type: string
-          description: "Heat Wave - Exposure - Total"
-        HWAV_EXP_AREA:
-          type: string
-          description: "Heat Wave - Exposure - Impacted Area (sq mi)"
-        HWAV_HLRA:
-          type: string
-          description: "Heat Wave - Historic Loss Ratio - Agriculture"
-        HWAV_HLRB:
-          type: string
-          description: "Heat Wave - Historic Loss Ratio - Buildings"
-        HWAV_HLRP:
-          type: string
-          description: "Heat Wave - Historic Loss Ratio - Population"
-        HWAV_HLRR:
-          type: string
-          description: "Heat Wave - Historic Loss Ratio - Total Rating"
-        HWAV_RISKR:
-          type: string
-          description: "Heat Wave - Hazard Type Risk Index Rating"
-        HWAV_RISKS:
-          type: string
-          description: "Heat Wave - Hazard Type Risk Index Score"
-        HWAV_RISKV:
-          type: string
-          description: "Heat Wave - Hazard Type Risk Index Value"
-        ISTM_AFREQ:
-          type: string
-          description: "Ice Storm - Annualized Frequency"
-        ISTM_ALRB:
-          type: string
-          description: "Ice Storm - Expected Annual Loss Rate - Building"
-        ISTM_ALRP:
-          type: string
-          description: "Ice Storm - Expected Annual Loss Rate - Population"
-        ISTM_ALR_NPCTL:
-          type: string
-          description: "Ice Storm - Expected Annual Loss Rate - National Percentile"
-        ISTM_EALB:
-          type: string
-          description: "Ice Storm - Expected Annual Loss - Building Value"
-        ISTM_EALP:
-          type: string
-          description: "Ice Storm - Expected Annual Loss - Population"
-        ISTM_EALPE:
-          type: string
-          description: "Ice Storm - Expected Annual Loss - Population Equivalence"
-        ISTM_EALR:
-          type: string
-          description: "Ice Storm - Expected Annual Loss Rating"
-        ISTM_EALS:
-          type: string
-          description: "Ice Storm - Expected Annual Loss Score"
-        ISTM_EALT:
-          type: string
-          description: "Ice Storm - Expected Annual Loss - Total"
-        ISTM_EVNTS:
-          type: string
-          description: "Ice Storm - Number of Events"
-        ISTM_EXPB:
-          type: string
-          description: "Ice Storm - Exposure - Building Value"
-        ISTM_EXPP:
-          type: string
-          description: "Ice Storm - Exposure - Population"
-        ISTM_EXPPE:
-          type: string
-          description: "Ice Storm - Exposure - Population Equivalence"
-        ISTM_EXPT:
-          type: string
-          description: "Ice Storm - Exposure - Total"
-        ISTM_EXP_AREA:
-          type: string
-          description: "Ice Storm - Exposure - Impacted Area (sq mi)"
-        ISTM_HLRB:
-          type: string
-          description: "Ice Storm - Historic Loss Ratio - Buildings"
-        ISTM_HLRP:
-          type: string
-          description: "Ice Storm - Historic Loss Ratio - Population"
-        ISTM_HLRR:
-          type: string
-          description: "Ice Storm - Historic Loss Ratio - Total Rating"
-        ISTM_RISKR:
-          type: string
-          description: "Ice Storm - Hazard Type Risk Index Rating"
-        ISTM_RISKS:
-          type: string
-          description: "Ice Storm - Hazard Type Risk Index Score"
-        ISTM_RISKV:
-          type: string
-          description: "Ice Storm - Hazard Type Risk Index Value"
-        LNDS_AFREQ:
-          type: string
-          description: "Landslide - Annualized Frequency"
-        LNDS_ALRB:
-          type: string
-          description: "Landslide - Expected Annual Loss Rate - Building"
-        LNDS_ALRP:
-          type: string
-          description: "Landslide - Expected Annual Loss Rate - Population"
-        LNDS_ALR_NPCTL:
-          type: string
-          description: "Landslide - Expected Annual Loss Rate - National Percentile"
-        LNDS_EALB:
-          type: string
-          description: "Landslide - Expected Annual Loss - Building Value"
-        LNDS_EALP:
-          type: string
-          description: "Landslide - Expected Annual Loss - Population"
-        LNDS_EALPE:
-          type: string
-          description: "Landslide - Expected Annual Loss - Population Equivalence"
-        LNDS_EALR:
-          type: string
-          description: "Landslide - Expected Annual Loss Rating"
-        LNDS_EALS:
-          type: string
-          description: "Landslide - Expected Annual Loss Score"
-        LNDS_EALT:
-          type: string
-          description: "Landslide - Expected Annual Loss - Total"
-        LNDS_EVNTS:
-          type: string
-          description: "Landslide - Number of Events"
-        LNDS_EXPB:
-          type: string
-          description: "Landslide - Exposure - Building Value"
-        LNDS_EXPP:
-          type: string
-          description: "Landslide - Exposure - Population"
-        LNDS_EXPPE:
-          type: string
-          description: "Landslide - Exposure - Population Equivalence"
-        LNDS_EXPT:
-          type: string
-          description: "Landslide - Exposure - Total"
-        LNDS_EXP_AREA:
-          type: string
-          description: "Landslide - Exposure - Impacted Area (sq mi)"
-        LNDS_HLRB:
-          type: string
-          description: "Landslide - Historic Loss Ratio - Buildings"
-        LNDS_HLRP:
-          type: string
-          description: "Landslide - Historic Loss Ratio - Population"
-        LNDS_HLRR:
-          type: string
-          description: "Landslide - Historic Loss Ratio - Total Rating"
-        LNDS_RISKR:
-          type: string
-          description: "Landslide - Hazard Type Risk Index Rating"
-        LNDS_RISKS:
-          type: string
-          description: "Landslide - Hazard Type Risk Index Score"
-        LNDS_RISKV:
-          type: string
-          description: "Landslide - Hazard Type Risk Index Value"
-        LTNG_AFREQ:
-          type: string
-          description: "Lightning - Annualized Frequency"
-        LTNG_ALRB:
-          type: string
-          description: "Lightning - Expected Annual Loss Rate - Building"
-        LTNG_ALRP:
-          type: string
-          description: "Lightning - Expected Annual Loss Rate - Population"
-        LTNG_ALR_NPCTL:
-          type: string
-          description: "Lightning - Expected Annual Loss Rate - National Percentile"
-        LTNG_EALB:
-          type: string
-          description: "Lightning - Expected Annual Loss - Building Value"
-        LTNG_EALP:
-          type: string
-          description: "Lightning - Expected Annual Loss - Population"
-        LTNG_EALPE:
-          type: string
-          description: "Lightning - Expected Annual Loss - Population Equivalence"
-        LTNG_EALR:
-          type: string
-          description: "Lightning - Expected Annual Loss Rating"
-        LTNG_EALS:
-          type: string
-          description: "Lightning - Expected Annual Loss Score"
-        LTNG_EALT:
-          type: string
-          description: "Lightning - Expected Annual Loss - Total"
-        LTNG_EVNTS:
-          type: string
-          description: "Lightning - Number of Events"
-        LTNG_EXPB:
-          type: string
-          description: "Lightning - Exposure - Building Value"
-        LTNG_EXPP:
-          type: string
-          description: "Lightning - Exposure - Population"
-        LTNG_EXPPE:
-          type: string
-          description: "Lightning - Exposure - Population Equivalence"
-        LTNG_EXPT:
-          type: string
-          description: "Lightning - Exposure - Total"
-        LTNG_EXP_AREA:
-          type: string
-          description: "Lightning - Exposure - Impacted Area (sq mi)"
-        LTNG_HLRB:
-          type: string
-          description: "Lightning - Historic Loss Ratio - Buildings"
-        LTNG_HLRP:
-          type: string
-          description: "Lightning - Historic Loss Ratio - Population"
-        LTNG_HLRR:
-          type: string
-          description: "Lightning - Historic Loss Ratio - Total Rating"
-        LTNG_RISKR:
-          type: string
-          description: "Lightning - Hazard Type Risk Index Rating"
-        LTNG_RISKS:
-          type: string
-          description: "Lightning - Hazard Type Risk Index Score"
-        LTNG_RISKV:
-          type: string
-          description: "Lightning - Hazard Type Risk Index Value"
-        NRI_VER:
-          type: string
-          description: "National Risk Index Version"
-        POPULATION:
-          type: string
-          description: "Population (2020)"
-        RESL_RATNG:
-          type: string
-          description: "Community Resilience - Rating"
-        RESL_SCORE:
-          type: string
-          description: "Community Resilience - Score"
-        RESL_SPCTL:
-          type: string
-          description: "Community Resilience - State Percentile"
-        RESL_VALUE:
-          type: string
-          description: "Community Resilience - Value"
-        RFLD_AFREQ:
-          type: string
-          description: "Riverine Flooding - Annualized Frequency"
-        RFLD_ALRA:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss Rate - Agriculture"
-        RFLD_ALRB:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss Rate - Building"
-        RFLD_ALRP:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss Rate - Population"
-        RFLD_ALR_NPCTL:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss Rate - National Percentile"
-        RFLD_EALA:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss - Agriculture Value"
-        RFLD_EALB:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss - Building Value"
-        RFLD_EALP:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss - Population"
-        RFLD_EALPE:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss - Population Equivalence"
-        RFLD_EALR:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss Rating"
-        RFLD_EALS:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss Score"
-        RFLD_EALT:
-          type: string
-          description: "Riverine Flooding - Expected Annual Loss - Total"
-        RFLD_EVNTS:
-          type: string
-          description: "Riverine Flooding - Number of Events"
-        RFLD_EXPA:
-          type: string
-          description: "Riverine Flooding - Exposure - Agriculture Value"
-        RFLD_EXPB:
-          type: string
-          description: "Riverine Flooding - Exposure - Building Value"
-        RFLD_EXPP:
-          type: string
-          description: "Riverine Flooding - Exposure - Population"
-        RFLD_EXPPE:
-          type: string
-          description: "Riverine Flooding - Exposure - Population Equivalence"
-        RFLD_EXPT:
-          type: string
-          description: "Riverine Flooding - Exposure - Total"
-        RFLD_EXP_AREA:
-          type: string
-          description: "Riverine Flooding - Exposure - Impacted Area (sq mi)"
-        RFLD_HLRA:
-          type: string
-          description: "Riverine Flooding - Historic Loss Ratio - Agriculture"
-        RFLD_HLRB:
-          type: string
-          description: "Riverine Flooding - Historic Loss Ratio - Buildings"
-        RFLD_HLRP:
-          type: string
-          description: "Riverine Flooding - Historic Loss Ratio - Population"
-        RFLD_HLRR:
-          type: string
-          description: "Riverine Flooding - Historic Loss Ratio - Total Rating"
-        RFLD_RISKR:
-          type: string
-          description: "Riverine Flooding - Hazard Type Risk Index Rating"
-        RFLD_RISKS:
-          type: string
-          description: "Riverine Flooding - Hazard Type Risk Index Score"
-        RFLD_RISKV:
-          type: string
-          description: "Riverine Flooding - Hazard Type Risk Index Value"
-        RISK_RATNG:
-          type: string
-          description: "National Risk Index - Rating - Composite"
-        RISK_SCORE:
-          type: string
-          description: "National Risk Index - Score - Composite"
-        RISK_SPCTL:
-          type: string
-          description: "National Risk Index - State Percentile - Composite"
-        RISK_VALUE:
-          type: string
-          description: "National Risk Index - Value - Composite"
-        SOVI_RATNG:
-          type: string
-          description: "Social Vulnerability - Rating"
-        SOVI_SCORE:
-          type: string
-          description: "Social Vulnerability - Score"
-        SOVI_SPCTL:
-          type: string
-          description: "Social Vulnerability - State Percentile"
-        STATE:
-          type: string
-          description: "State Name"
-        STATEABBRV:
-          type: string
-          description: "State Name Abbreviation"
-        STATEFIPS:
-          type: string
-          description: "State FIPS Code"
-        STCOFIPS:
-          type: string
-          description: "State-County FIPS Code"
-        SWND_AFREQ:
-          type: string
-          description: "Strong Wind - Annualized Frequency"
-        SWND_ALRA:
-          type: string
-          description: "Strong Wind - Expected Annual Loss Rate - Agriculture"
-        SWND_ALRB:
-          type: string
-          description: "Strong Wind - Expected Annual Loss Rate - Building"
-        SWND_ALRP:
-          type: string
-          description: "Strong Wind - Expected Annual Loss Rate - Population"
-        SWND_ALR_NPCTL:
-          type: string
-          description: "Strong Wind - Expected Annual Loss Rate - National Percentile"
-        SWND_EALA:
-          type: string
-          description: "Strong Wind - Expected Annual Loss - Agriculture Value"
-        SWND_EALB:
-          type: string
-          description: "Strong Wind - Expected Annual Loss - Building Value"
-        SWND_EALP:
-          type: string
-          description: "Strong Wind - Expected Annual Loss - Population"
-        SWND_EALPE:
-          type: string
-          description: "Strong Wind - Expected Annual Loss - Population Equivalence"
-        SWND_EALR:
-          type: string
-          description: "Strong Wind - Expected Annual Loss Rating"
-        SWND_EALS:
-          type: string
-          description: "Strong Wind - Expected Annual Loss Score"
-        SWND_EALT:
-          type: string
-          description: "Strong Wind - Expected Annual Loss - Total"
-        SWND_EVNTS:
-          type: string
-          description: "Strong Wind - Number of Events"
-        SWND_EXPA:
-          type: string
-          description: "Strong Wind - Exposure - Agriculture Value"
-        SWND_EXPB:
-          type: string
-          description: "Strong Wind - Exposure - Building Value"
-        SWND_EXPP:
-          type: string
-          description: "Strong Wind - Exposure - Population"
-        SWND_EXPPE:
-          type: string
-          description: "Strong Wind - Exposure - Population Equivalence"
-        SWND_EXPT:
-          type: string
-          description: "Strong Wind - Exposure - Total"
-        SWND_EXP_AREA:
-          type: string
-          description: "Strong Wind - Exposure - Impacted Area (sq mi)"
-        SWND_HLRA:
-          type: string
-          description: "Strong Wind - Historic Loss Ratio - Agriculture"
-        SWND_HLRB:
-          type: string
-          description: "Strong Wind - Historic Loss Ratio - Buildings"
-        SWND_HLRP:
-          type: string
-          description: "Strong Wind - Historic Loss Ratio - Population"
-        SWND_HLRR:
-          type: string
-          description: "Strong Wind - Historic Loss Ratio - Total Rating"
-        SWND_RISKR:
-          type: string
-          description: "Strong Wind - Hazard Type Risk Index Rating"
-        SWND_RISKS:
-          type: string
-          description: "Strong Wind - Hazard Type Risk Index Score"
-        SWND_RISKV:
-          type: string
-          description: "Strong Wind - Hazard Type Risk Index Value"
-        TRACT:
-          type: string
-          description: "Census Tract"
-        TRACTFIPS:
-          type: string
-          description: "Census Tract FIPS Code"
-        TRND_AFREQ:
-          type: string
-          description: "Tornado - Annualized Frequency"
-        TRND_ALRA:
-          type: string
-          description: "Tornado - Expected Annual Loss Rate - Agriculture"
-        TRND_ALRB:
-          type: string
-          description: "Tornado - Expected Annual Loss Rate - Building"
-        TRND_ALRP:
-          type: string
-          description: "Tornado - Expected Annual Loss Rate - Population"
-        TRND_ALR_NPCTL:
-          type: string
-          description: "Tornado - Expected Annual Loss Rate - National Percentile"
-        TRND_EALA:
-          type: string
-          description: "Tornado - Expected Annual Loss - Agriculture Value"
-        TRND_EALB:
-          type: string
-          description: "Tornado - Expected Annual Loss - Building Value"
-        TRND_EALP:
-          type: string
-          description: "Tornado - Expected Annual Loss - Population"
-        TRND_EALPE:
-          type: string
-          description: "Tornado - Expected Annual Loss - Population Equivalence"
-        TRND_EALR:
-          type: string
-          description: "Tornado - Expected Annual Loss Rating"
-        TRND_EALS:
-          type: string
-          description: "Tornado - Expected Annual Loss Score"
-        TRND_EALT:
-          type: string
-          description: "Tornado - Expected Annual Loss - Total"
-        TRND_EVNTS:
-          type: string
-          description: "Tornado - Number of Events"
-        TRND_EXPA:
-          type: string
-          description: "Tornado - Exposure - Agriculture Value"
-        TRND_EXPB:
-          type: string
-          description: "Tornado - Exposure - Building Value"
-        TRND_EXPP:
-          type: string
-          description: "Tornado - Exposure - Population"
-        TRND_EXPPE:
-          type: string
-          description: "Tornado - Exposure - Population Equivalence"
-        TRND_EXPT:
-          type: string
-          description: "Tornado - Exposure - Total"
-        TRND_EXP_AREA:
-          type: string
-          description: "Tornado - Exposure - Impacted Area (sq mi)"
-        TRND_HLRA:
-          type: string
-          description: "Tornado - Historic Loss Ratio - Agriculture"
-        TRND_HLRB:
-          type: string
-          description: "Tornado - Historic Loss Ratio - Buildings"
-        TRND_HLRP:
-          type: string
-          description: "Tornado - Historic Loss Ratio - Population"
-        TRND_HLRR:
-          type: string
-          description: "Tornado - Historic Loss Ratio - Total Rating"
-        TRND_RISKR:
-          type: string
-          description: "Tornado - Hazard Type Risk Index Rating"
-        TRND_RISKS:
-          type: string
-          description: "Tornado - Hazard Type Risk Index Score"
-        TRND_RISKV:
-          type: string
-          description: "Tornado - Hazard Type Risk Index Value"
-        TSUN_AFREQ:
-          type: string
-          description: "Tsunami - Annualized Frequency"
-        TSUN_ALRB:
-          type: string
-          description: "Tsunami - Expected Annual Loss Rate - Building"
-        TSUN_ALRP:
-          type: string
-          description: "Tsunami - Expected Annual Loss Rate - Population"
-        TSUN_ALR_NPCTL:
-          type: string
-          description: "Tsunami - Expected Annual Loss Rate - National Percentile"
-        TSUN_EALB:
-          type: string
-          description: "Tsunami - Expected Annual Loss - Building Value"
-        TSUN_EALP:
-          type: string
-          description: "Tsunami - Expected Annual Loss - Population"
-        TSUN_EALPE:
-          type: string
-          description: "Tsunami - Expected Annual Loss - Population Equivalence"
-        TSUN_EALR:
-          type: string
-          description: "Tsunami - Expected Annual Loss Rating"
-        TSUN_EALS:
-          type: string
-          description: "Tsunami - Expected Annual Loss Score"
-        TSUN_EALT:
-          type: string
-          description: "Tsunami - Expected Annual Loss - Total"
-        TSUN_EVNTS:
-          type: string
-          description: "Tsunami - Number of Events"
-        TSUN_EXPB:
-          type: string
-          description: "Tsunami - Exposure - Building Value"
-        TSUN_EXPP:
-          type: string
-          description: "Tsunami - Exposure - Population"
-        TSUN_EXPPE:
-          type: string
-          description: "Tsunami - Exposure - Population Equivalence"
-        TSUN_EXPT:
-          type: string
-          description: "Tsunami - Exposure - Total"
-        TSUN_EXP_AREA:
-          type: string
-          description: "Tsunami - Exposure - Impacted Area (sq mi)"
-        TSUN_HLRB:
-          type: string
-          description: "Tsunami - Historic Loss Ratio - Buildings"
-        TSUN_HLRP:
-          type: string
-          description: "Tsunami - Historic Loss Ratio - Population"
-        TSUN_HLRR:
-          type: string
-          description: "Tsunami - Historic Loss Ratio - Total Rating"
-        TSUN_RISKR:
-          type: string
-          description: "Tsunami - Hazard Type Risk Index Rating"
-        TSUN_RISKS:
-          type: string
-          description: "Tsunami - Hazard Type Risk Index Score"
-        TSUN_RISKV:
-          type: string
-          description: "Tsunami - Hazard Type Risk Index Value"
-        VLCN_AFREQ:
-          type: string
-          description: "Volcanic Activity - Annualized Frequency"
-        VLCN_ALRB:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss Rate - Building"
-        VLCN_ALRP:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss Rate - Population"
-        VLCN_ALR_NPCTL:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss Rate - National Percentile"
-        VLCN_EALB:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss - Building Value"
-        VLCN_EALP:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss - Population"
-        VLCN_EALPE:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss - Population Equivalence"
-        VLCN_EALR:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss Rating"
-        VLCN_EALS:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss Score"
-        VLCN_EALT:
-          type: string
-          description: "Volcanic Activity - Expected Annual Loss - Total"
-        VLCN_EVNTS:
-          type: string
-          description: "Volcanic Activity - Number of Events"
-        VLCN_EXPB:
-          type: string
-          description: "Volcanic Activity - Exposure - Building Value"
-        VLCN_EXPP:
-          type: string
-          description: "Volcanic Activity - Exposure - Population"
-        VLCN_EXPPE:
-          type: string
-          description: "Volcanic Activity - Exposure - Population Equivalence"
-        VLCN_EXPT:
-          type: string
-          description: "Volcanic Activity - Exposure - Total"
-        VLCN_EXP_AREA:
-          type: string
-          description: "Volcanic Activity - Exposure - Impacted Area (sq mi)"
-        VLCN_HLRB:
-          type: string
-          description: "Volcanic Activity - Historic Loss Ratio - Buildings"
-        VLCN_HLRP:
-          type: string
-          description: "Volcanic Activity - Historic Loss Ratio - Population"
-        VLCN_HLRR:
-          type: string
-          description: "Volcanic Activity - Historic Loss Ratio - Total Rating"
-        VLCN_RISKR:
-          type: string
-          description: "Volcanic Activity - Hazard Type Risk Index Rating"
-        VLCN_RISKS:
-          type: string
-          description: "Volcanic Activity - Hazard Type Risk Index Score"
-        VLCN_RISKV:
-          type: string
-          description: "Volcanic Activity - Hazard Type Risk Index Value"
-        WFIR_AFREQ:
-          type: string
-          description: "Wildfire - Annualized Frequency"
-        WFIR_ALRA:
-          type: string
-          description: "Wildfire - Expected Annual Loss Rate - Agriculture"
-        WFIR_ALRB:
-          type: string
-          description: "Wildfire - Expected Annual Loss Rate - Building"
-        WFIR_ALRP:
-          type: string
-          description: "Wildfire - Expected Annual Loss Rate - Population"
-        WFIR_ALR_NPCTL:
-          type: string
-          description: "Wildfire - Expected Annual Loss Rate - National Percentile"
-        WFIR_EALA:
-          type: string
-          description: "Wildfire - Expected Annual Loss - Agriculture Value"
-        WFIR_EALB:
-          type: string
-          description: "Wildfire - Expected Annual Loss - Building Value"
-        WFIR_EALP:
-          type: string
-          description: "Wildfire - Expected Annual Loss - Population"
-        WFIR_EALPE:
-          type: string
-          description: "Wildfire - Expected Annual Loss - Population Equivalence"
-        WFIR_EALR:
-          type: string
-          description: "Wildfire - Expected Annual Loss Rating"
-        WFIR_EALS:
-          type: string
-          description: "Wildfire - Expected Annual Loss Score"
-        WFIR_EALT:
-          type: string
-          description: "Wildfire - Expected Annual Loss - Total"
-        WFIR_EVNTS:
-          type: string
-          description: "Wildfire - Number of Events"
-        WFIR_EXPA:
-          type: string
-          description: "Wildfire - Exposure - Agriculture Value"
-        WFIR_EXPB:
-          type: string
-          description: "Wildfire - Exposure - Building Value"
-        WFIR_EXPP:
-          type: string
-          description: "Wildfire - Exposure - Population"
-        WFIR_EXPPE:
-          type: string
-          description: "Wildfire - Exposure - Population Equivalence"
-        WFIR_EXPT:
-          type: string
-          description: "Wildfire - Exposure - Total"
-        WFIR_EXP_AREA:
-          type: string
-          description: "Wildfire - Exposure - Impacted Area (sq mi)"
-        WFIR_HLRA:
-          type: string
-          description: "Wildfire - Historic Loss Ratio - Agriculture"
-        WFIR_HLRB:
-          type: string
-          description: "Wildfire - Historic Loss Ratio - Buildings"
-        WFIR_HLRP:
-          type: string
-          description: "Wildfire - Historic Loss Ratio - Population"
-        WFIR_HLRR:
-          type: string
-          description: "Wildfire - Historic Loss Ratio - Total Rating"
-        WFIR_RISKR:
-          type: string
-          description: "Wildfire - Hazard Type Risk Index Rating"
-        WFIR_RISKS:
-          type: string
-          description: "Wildfire - Hazard Type Risk Index Score"
-        WFIR_RISKV:
-          type: string
-          description: "Wildfire - Hazard Type Risk Index Value"
-        WNTW_AFREQ:
-          type: string
-          description: "Winter Weather - Annualized Frequency"
-        WNTW_ALRA:
-          type: string
-          description: "Winter Weather - Expected Annual Loss Rate - Agriculture"
-        WNTW_ALRB:
-          type: string
-          description: "Winter Weather - Expected Annual Loss Rate - Building"
-        WNTW_ALRP:
-          type: string
-          description: "Winter Weather - Expected Annual Loss Rate - Population"
-        WNTW_ALR_NPCTL:
-          type: string
-          description: "Winter Weather - Expected Annual Loss Rate - National Percentile"
-        WNTW_EALA:
-          type: string
-          description: "Winter Weather - Expected Annual Loss - Agriculture Value"
-        WNTW_EALB:
-          type: string
-          description: "Winter Weather - Expected Annual Loss - Building Value"
-        WNTW_EALP:
-          type: string
-          description: "Winter Weather - Expected Annual Loss - Population"
-        WNTW_EALPE:
-          type: string
-          description: "Winter Weather - Expected Annual Loss - Population Equivalence"
-        WNTW_EALR:
-          type: string
-          description: "Winter Weather - Expected Annual Loss Rating"
-        WNTW_EALS:
-          type: string
-          description: "Winter Weather - Expected Annual Loss Score"
-        WNTW_EALT:
-          type: string
-          description: "Winter Weather - Expected Annual Loss - Total"
-        WNTW_EVNTS:
-          type: string
-          description: "Winter Weather - Number of Events"
-        WNTW_EXPA:
-          type: string
-          description: "Winter Weather - Exposure - Agriculture Value"
-        WNTW_EXPB:
-          type: string
-          description: "Winter Weather - Exposure - Building Value"
-        WNTW_EXPP:
-          type: string
-          description: "Winter Weather - Exposure - Population"
-        WNTW_EXPPE:
-          type: string
-          description: "Winter Weather - Exposure - Population Equivalence"
-        WNTW_EXPT:
-          type: string
-          description: "Winter Weather - Exposure - Total"
-        WNTW_EXP_AREA:
-          type: string
-          description: "Winter Weather - Exposure - Impacted Area (sq mi)"
-        WNTW_HLRA:
-          type: string
-          description: "Winter Weather - Historic Loss Ratio - Agriculture"
-        WNTW_HLRB:
-          type: string
-          description: "Winter Weather - Historic Loss Ratio - Buildings"
-        WNTW_HLRP:
-          type: string
-          description: "Winter Weather - Historic Loss Ratio - Population"
-        WNTW_HLRR:
-          type: string
-          description: "Winter Weather - Historic Loss Ratio - Total Rating"
-        WNTW_RISKR:
-          type: string
-          description: "Winter Weather - Hazard Type Risk Index Rating"
-        WNTW_RISKS:
-          type: string
-          description: "Winter Weather - Hazard Type Risk Index Score"
-        WNTW_RISKV:
-          type: string
-          description: "Winter Weather - Hazard Type Risk Index Value"
     RootAddress:
       type: object
       properties:
@@ -2939,9 +1425,8 @@ components:
           type: string
         plus4_code:
           type: string
-
   responses:
-    PropertyPrincipalResponseSearch:
+    PropertyResponseSearch:
       description: Ok Response
       content:
         application/json:
@@ -2949,8 +1434,8 @@ components:
             type: array
             items:
               type: object
-              $ref: '#/components/schemas/PropertyPrincipalResponseSearch'
-    PropertyPrincipalResponseSmartyKey:
+              $ref: '#/components/schemas/PropertyResponseSearch'
+    PropertyResponseSmartyKey:
       description: Ok Response
       content:
         application/json:
@@ -2958,8 +1443,8 @@ components:
             type: array
             items:
               type: object
-              $ref: '#/components/schemas/PropertyPrincipalResponseSmartyKey'
-    PropertyFinancialResponseSearch:
+              $ref: '#/components/schemas/PropertyResponseSmartyKey'
+    CensusBlockAndTractResponseSearch:
       description: Ok Response
       content:
         application/json:
@@ -2967,8 +1452,8 @@ components:
             type: array
             items:
               type: object
-              $ref: '#/components/schemas/PropertyFinancialResponseSearch'
-    PropertyFinancialResponseSmartyKey:
+              $ref: '#/components/schemas/CensusBlockAndTractResponseSearch'
+    CensusBlockAndTractResponseSmartyKey:
       description: Ok Response
       content:
         application/json:
@@ -2976,43 +1461,7 @@ components:
             type: array
             items:
               type: object
-              $ref: '#/components/schemas/PropertyFinancialResponseSmartyKey'
-    GeoReferenceResponseSearch:
-      description: Ok Response
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              type: object
-              $ref: '#/components/schemas/GeoReferenceResponseSearch'
-    GeoReferenceResponseSmartyKey:
-      description: Ok Response
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              type: object
-              $ref: '#/components/schemas/GeoReferenceResponseSmartyKey'
-    RiskResponseSearch:
-      description: Ok Response
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              type: object
-              $ref: '#/components/schemas/RiskResponseSearch'
-    RiskResponseSmartyKey:
-      description: Ok Response
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              type: object
-              $ref: '#/components/schemas/RiskResponseSmartyKey'
+              $ref: '#/components/schemas/CensusBlockAndTractResponseSmartyKey'
     SecondaryResponseSearch:
       description: Ok Response
       content:
@@ -3053,6 +1502,9 @@ components:
     BadRequest:
       description: >
         Bad Request (Malformed Payload): A GET request lacked a street field, or the request body of a POST request contained malformed JSON. (example: submitting an integer value in the ZIP Code field when a string is expected)
+    NotModified:
+      description: >
+        The requested ETag header represents the latest data available.
     Unauthorized:
       description: >
         Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.
@@ -3067,7 +1519,7 @@ components:
         Unprocessable content: Some parameter values are not correct. Detailed messages will describe the problem.
     TooManyRequests:
       description: >
-        Too Many Requests: When using public embedded key authentication, we restrict the number of requests.
+        Too Many Requests: We restrict the number of requests coming from a given source over too short of a time.
   securitySchemes:
     auth-id:
       name: auth-id

--- a/us-extract-api.yaml
+++ b/us-extract-api.yaml
@@ -195,36 +195,57 @@ components:
       title: APIOutput
       type: object
       properties:
+        input_id:
+          type: string
+          maxLength: 36
+          description: Any unique identifier that you use to reference the input address; the output will be identical to the input.
+        input_index:
+          type: integer
+          description: |-
+            The order in which this address was submitted with the others
+            (0 if alone)
         candidate_index:
           type: integer
           description: |-
             An input address can match multiple valid addresses. This ties the candidates to the input index. 
             (e.g., "1 Rosedale Street Baltimore Maryland" will return multiple candidates.)
+        addressee:
+          type: string
+          description: 'The name of the person or company at this address. This value is taken directly from the addressee input field. Very rarely, this field might be filled automatically based on the USPS address record.'
+          maxLength: 64
         delivery_line_1:
           type: string
           description: |-
             Contains the first delivery line (usually the street address). This can include any of the following: 
-            urbanization (Puerto Rico only)
-            primary number
-            street predirection
-            street name
-            street suffix
-            street postdirection
-            secondary designator
-            secondary number
-            extra secondary designator
-            extra secondary number
-            PMB designator
-            PMB number
-          maxLength: 50
+            - urbanization (Puerto Rico only)
+            - primary number
+            - street predirection
+            - street name
+            - street suffix
+            - street postdirection
+            - secondary designator
+            - secondary number
+            - extra secondary designator
+            - extra secondary number
+            - PMB designator
+            - PMB number
+          maxLength: 64
+        delivery_line_2:
+          type: string
+          description: 'The second delivery line (if needed). It is common for this field to remain empty, but it may contain a private mailbox number.'
+          maxLength: 64
         last_line:
           type: string
           description: 'City, state, and ZIP Code combined'
-          maxLength: 50
+          maxLength: 64
         delivery_point_barcode:
           type: string
           description: '12-digit POSTNET™ barcode; consists of 5-digit ZIP Code, 4-digit add-on code, 2-digit delivery point, and 1-digit check digit.'
           maxLength: 12
+        smarty_key:
+          type: string
+          description: "Smarty's unique identifier for an address. This identifier will only be displayed when an address is submitted with the match parameter set to enhanced, with an appropriate product subscription."
+          maxLength: 10
         components:
           $ref: '#/components/schemas/ComponentsObject'
         metadata:
@@ -236,6 +257,10 @@ components:
       type: object
       description: Object representing the different components of a verified address
       properties:
+        urbanization:
+          type: string
+          maxLength: 64
+          description: 'The neighborhood, or city subdivision; used with Puerto Rican addresses'
         primary_number:
           type: string
           description: 'The house, PO Box, or building number'
@@ -244,13 +269,53 @@ components:
           type: string
           description: The name of the street
           maxLength: 64
+        street_predirection:
+          type: string
+          maxLength: 16
+          description: 'Directional information before a street name (N, SW, etc.)'
+        street_postdirection:
+          type: string
+          description: 'Directional information after a street name (N, SW, etc.)'
+          maxLength: 16
         street_suffix:
           type: string
           description: 'Abbreviated value describing the street (St, Ave, Blvd, etc.)'
           maxLength: 16
+        secondary_number:
+          type: string
+          description: 'Apartment or suite number, if any'
+          maxLength: 32
+        secondary_designator:
+          type: string
+          description: 'Describes location within a complex/building (Ste, Apt, etc.)'
+          maxLength: 16
+        extra_secondary_number:
+          type: string
+          description: |-
+            Descriptive information about the location of a building within a campus 
+            (e.g., E-5 in "5619 Loop 1604, Bldg E-5, Ste. 101 San Antonio TX")
+          maxLength: 32
+        extra_secondary_designator:
+          type: string
+          description: |-
+            Description of the location type within a campus 
+            (e.g., Bldg, Unit, Lot, etc.)
+          maxLength: 16
+        pmb_designator:
+          type: string
+          description: 'The private mailbox unit designator, assigned by a CMRA'
+          maxLength: 16
+        pmb_number:
+          type: string
+          description: 'The private mailbox number, assigned by a CMRA'
+          maxLength: 16
         city_name:
           type: string
           description: 'The USPS-preferred city name for this particular address, or an acceptable alternate if provided by the user'
+          maxLength: 64
+        default_city_name:
+          type: string
+          description: The default city name for this 5-digit ZIP Code
           maxLength: 64
         state_abbreviation:
           type: string
@@ -313,6 +378,14 @@ components:
           type: string
           maxLength: 5
           description: The name of the county in which the address is located
+        ews_match:
+          type: string
+          maxLength: 5
+          description: |-
+            Early warning system flag; a positive result indicates the street of the address is not yet ready for mail delivery and that the address will soon be added to the master ZIP+4 file in the coming weeks or months. This commonly occurs for new streets or streets undergoing a name change. 
+
+            true — The address was flagged by EWS, preventing a ZIP+4 match.
+            [blank] — Address was not flagged by EWS.
         carrier_route:
           type: string
           maxLength: 4
@@ -331,6 +404,14 @@ components:
           type: string
           maxLength: 2
           description: 'The congressional district to which the address belongs. Output will be two digits from 01 - 53 or "AL." "AL" means that the entire state (or territory) is covered by a single congressional district. These include Alaska, Delaware, Montana, North Dakota, South Dakota, Vermont, Wyoming, Washington DC, Virgin Islands, and other territories.'
+        building_default_indicator:
+          type: string
+          maxLength: 1
+          description: |-
+            Indicates whether the address is the "default" address for a building; for example, the main lobby 
+
+            Y — Yes
+            N — No
         rdi:
           type: string
           maxLength: 12
@@ -361,22 +442,25 @@ components:
         longitude:
           type: number
           description: 'The vertical component used for geographic positioning. It is the angle between 0° (the Prime Meridian) and ±180° (westward or eastward). It is the second number in an ordered pair of (latitude, longitude). A negative number indicates a location west of Greenwich, England; a positive number east. Combining lat/long values enables you to pinpoint addresses on a map.'
+        coordinate_license:
+          type: integer
+          description: The license ID for the geographic coordinate returned. See the licensing table below for more details.
         precision:
           type: string
           maxLength: 18
           description: |-
-            Indicates the precision of the latitude and longitude values.
+            Indicates the precision of the latitude and longitude values. 
 
             Unknown — Coordinates not known. Reasons could include: address is invalid, military address (APO or FPO), lat/lon coordinates not available.
-              Zip5 — Accurate to a 5-digit ZIP Code level (least precise)
-              Zip6 — Accurate to a 6-digit ZIP Code level
-              Zip7 — Accurate to a 7-digit ZIP Code level
-              Zip8 — Accurate to an 8-digit ZIP Code level
-              Zip9 — Accurate to a 9-digit ZIP Code level (most precise with the basic subscription)
-              Street — Accurate to a position along the street proportional to the house/building number.
-              Parcel — Accurate to the centroid of a property parcel. Requires the US Rooftop Geocoding subscription.
-              Rooftop — Accurate to the rooftop of a structure for this address. Requires the US Rooftop Geocoding subscription.
-            
+            Zip5 — Accurate to a 5-digit ZIP Code level (least precise)
+            Zip6 — Accurate to a 6-digit ZIP Code level
+            Zip7 — Accurate to a 7-digit ZIP Code level
+            Zip8 — Accurate to an 8-digit ZIP Code level
+            Zip9 — Accurate to a 9-digit ZIP Code level (most precise with the basic subscription)
+            Street — Accurate to a position along the street proportional to the house/building number.
+            Parcel — Accurate to the centroid of a property parcel. Requires the US Rooftop Geocoding subscription.
+            Rooftop — Accurate to the rooftop of a structure for this address. Requires the US Rooftop Geocoding subscription.
+
             Note: Concerning addresses for which the ZIP9 precision is not available, the ZIP# precision is interpolated based on neighboring addresses. Thus, ZIP7 is an average of all the lat/long coordinates of nearby ZIP Codes that share those first 7 digits.
         time_zone:
           type: string
@@ -411,14 +495,14 @@ components:
           type: string
           maxLength: 1
           description: |-
-            Status of the Delivery Point Validation (DPV). This indicates whether or not the address is present in the USPS data.
-            
-            Y — Confirmed; entire address is present in the USPS data. (To be certain the address is actually deliverable, verify that the dpv_vacant field has a value of N. You may also want to verify that the dpv_no_stat field has a value of N. However, the USPS is often several months behind in updating this data point, so only rely on the dpv_no_stat data if you are fully aware of its weaknesses and limitations.)
+            Status of the Delivery Point Validation (DPV). This indicates whether or not the address is present in the USPS data. 
+
+            Y — Confirmed; entire address is present in the USPS data. (To be certain the address is actually deliverable, verify that the dpv_vacant field has a value of N. You may also want to verify that the dpv_no_stat field has a value of N. However, the USPS is often several months behind in updating this data point, so only rely on the dpv_no_stat data if you are fully aware of its weaknesses and limitations.) 
             (e.g., 1600 Amphitheatre Pkwy Mountain View, CA)
             N — Not confirmed; address is not present in the USPS data.
-            S — Confirmed by ignoring secondary info; the main address is present in the USPS data, but the submitted secondary information (apartment, suite, etc.) was not recognized.
+            S — Confirmed by ignoring secondary info; the main address is present in the USPS data, but the submitted secondary information (apartment, suite, etc.) was not recognized. 
             (e.g., 62 Ea Darden Dr Apt 298 Anniston, AL)
-            D — Confirmed but missing secondary info; the main address is present in the USPS data, but it is missing secondary information (apartment, suite, etc.).
+            D — Confirmed but missing secondary info; the main address is present in the USPS data, but it is missing secondary information (apartment, suite, etc.). 
             (e.g., 122 Mast Rd Lee, NH)
             [blank or null] — The address is not present in the USPS database.
         dpv_footnotes:
@@ -426,7 +510,7 @@ components:
           maxLength: 32
           description: |-
             Information related to the delivery point validation of this address. All these footnotes have a length of 2 characters, and there may be up to 14 footnotes.
-            
+
             AA — Street name, city, state, and ZIP are all valid.
             (e.g., 2335 S State St Ste 300 Provo UT)
             A1 — Address not present in USPS data.
@@ -445,7 +529,7 @@ components:
             (e.g., N University Ave Provo UT)
             M3 — Primary number (e.g., house number) is invalid.
             (e.g., 16 N University Ave Provo UT)
-            N1 — Address is missing secondary information (apartment, suite, etc.) which IS REQUIRED for delivery..
+            N1 — Address is missing secondary information (apartment, suite, etc.).
             (e.g., 2335 S State St Provo UT)
             PB — PO Box street style address.
             (e.g., 555 S B B King Blvd Unit 1 Memphis TN 38103)
@@ -463,15 +547,15 @@ components:
             (e.g., 4-C PENINSULA CTR RANCHO PALOS VERDES CA 90274)
             U1 — Address has a "unique" ZIP Code.
             (e.g., 100 North Happy Street 12345)
-          
+
             Here are some common combinations:
-              AABB - ZIP, state, city, street name, and primary number match.
-              AABBCC - ZIP, state, city, street name, and primary number match, but secondary does not. A secondary is not required for delivery.
-              AAC1 - ZIP, state, city, street name, and primary number match, but secondary does not. A secondary is required for delivery.
-              AAM1 - ZIP, state, city, and street name match, but the primary number is missing.
-              AAM3 - ZIP, state, city, and street name match, but the primary number is invalid.
-              AAN1 - ZIP, state, city, street name, and primary number match, but there is secondary information such as apartment or suite that would be helpful.
-              AABBR1 - ZIP, state, city, street name, and primary number match. Address confirmed without private mailbox (PMB) info.
+            AABB - ZIP, state, city, street name, and primary number match.
+            AABBCC - ZIP, state, city, street name, and primary number match, but secondary does not. A secondary is NOT required for delivery.
+            AAC1 - ZIP, state, city, street name, and primary number match, but secondary does not. A secondary is required for delivery.
+            AAM1 - ZIP, state, city, and street name match, but the primary number is missing.
+            AAM3 - ZIP, state, city, and street name match, but the primary number is invalid.
+            AAN1 - ZIP, state, city, street name, and primary number match, but there is secondary information such as apartment or suite that would be helpful.
+            AABBR1 - ZIP, state, city, street name, and primary number match. Address confirmed without private mailbox (PMB) info.
         dpv_cmra:
           type: string
           maxLength: 1
@@ -490,6 +574,15 @@ components:
             Y — Address is vacant.
             N — Address is not vacant.
             [blank] — Address was not submitted for vacancy verification.
+        dpv_no_stat:
+          type: string
+          maxLength: 1
+          description: |-
+            Indicates that a delivery point is listed as "no-stat" by the USPS. Technically, that means the USPS is temporarily declaring the address undeliverable. In practice, however, the USPS is often several months behind in removing addresses from the "no-stat" list, so only rely on this data point if you are fully aware of its weaknesses and limitations. 
+
+            Y — USPS lists the address as "no-stat."
+            N — USPS does not list the address as "no-stat."
+            [blank] — Address was not submitted for "no-stat" verification.
         active:
           type: string
           maxLength: 1
@@ -498,6 +591,49 @@ components:
           type: string
           maxLength: 12
           description: 'Indicates which changes were made to the input address. Footnotes are delimited by a # character. See the footnotes table below for details.'
+        lacslink_code:
+          type: string
+          maxLength: 2
+          description: |-
+            The reason for the LACSLink indication that was given (below) 
+
+            A — Match: Address provided. LACSLink record match was found, and a converted address was provided.
+            00 — No Match. No converted address. No soup for you!
+            09 — Match: No new address. LACSLink matched an input address to an old address which is a "high-rise default" address; no new address was provided.
+            14 — Match: No conversion. Found a LACSLink record, but couldn't convert the data to a deliverable address.
+            92 — Match: Dropped secondary number. LACSLink record was matched after dropping the secondary number from input.
+            [blank] — No LACSLink lookup attempted.
+        lacslink_indicator:
+          type: string
+          maxLength: 1
+          description: |-
+            Indicates whether there is an address match in the LACSLink database. 
+
+            Y — LACS record match; a new address could be furnished because the input record matched a record in the master file.
+            S — LACS record - secondary number dropped; the record is a ZIP+4 street level or high-rise match. The input record matched a master file record, but the input address had a secondary number and the master file record did not.
+            N — No match; a new address could not be furnished; the input record could not be matched to a record in the master file.
+            F — False positive; a false positive record was detected.
+            [blank] — No LACSLink lookup attempted.
+        suitelink_match:
+          type: string
+          maxLength: 5
+          description: |-
+            Indicates a match (or not) to the USPS SuiteLink data. SuiteLink attempts to provide secondary information such as "suite" or "apartment" whenever there is a match based on address and company name. 
+
+            true — There was a SuiteLink match and the result is provided.
+            false — There was no SuiteLink match.
+        enhanced_match:
+          type: string
+          maxLength: 64
+          description: |-
+            When an address is submitted with the match parameter set to "enhanced," this field will contain additional information about the result. Multiple values may be present, separated by commas. Additional values will be added from time to time. The current possible values are:
+
+            none — No address match was found.
+            non-postal-match — A match was found within additional, non-postal address data.
+            postal-match — A match was found within postal address data.
+            missing-secondary — The address should have a secondary (e.g., apartment), but none was found in the input.
+            unknown-secondary — The provided secondary information did not match a known secondary within the address data.
+            ignored-input — The provided input contained information that was not used for a match.
       description: Object representing the different metadata of a verified address
   securitySchemes:
     auth_id:

--- a/us-extract-api.yaml
+++ b/us-extract-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: US-Extract-API
   description: |
-    So you don't like playing 'Wheres Waldo' to find addresses in sentences, the SmartyStreets US-Extract RESTful API has your back. 
+    So you don't like playing 'Wheres Waldo' to find addresses in sentences? The SmartyStreets US-Extract RESTful API has your back. 
   termsOfService: 'https://www.smarty.com/legal/terms-of-service'
   license:
     url: 'https://www.smarty.com/legal/terms-of-service'
@@ -47,6 +47,8 @@ paths:
           description: Payment Required
         '413':
           description: Request Entity Too Large
+        '422':
+          description: Unprocessable Entity
         '429':
           description: Too Many Requests
       parameters:
@@ -67,6 +69,20 @@ tags:
     description: Find an address in a sentence
 components:
   parameters:
+    Host:
+      name: Host
+      in: header
+      required: true
+      schema:
+        type: string
+      description: 'The Host request header field specifies the internet host and port number of the resource being requested. Ex: Host: us-extract.api.smarty.com'
+    Content-Type:
+      name: Content-Type
+      in: header
+      required: true
+      schema:
+        type: string
+      description: 'The purpose of the Content-Type field is to describe the data contained in the body fully enough that the receiving user agent can pick an appropriate agent or mechanism to present the data to the user, or otherwise deal with the data in an appropriate manner. Ex: Content-Type: text/plain; charset=utf-8'
     html:
       name: html
       in: query
@@ -101,27 +117,14 @@ components:
       required: false
       schema:
         type: string
+      description: 'Specifies the license or licenses (comma separated) to use for this lookup. Valid values cn be found in your Subscriptions Page. If multiple licenses are specified, they are considered to be in left to right order. As a default, this value is derived.'
     match:
       name: match
       in: query
       required: false
       schema:
         type: string
-      description: 'The match output strategy to be employed for this lookup. See more here: https://www.smarty.com/docs/cloud/us-street-api#match'
-    Content-Type:
-      name: Content-Type
-      in: header
-      required: true
-      schema:
-        type: string
-      description: 'The purpose of the Content-Type field is to describe the data contained in the body fully enough that the receiving user agent can pick an appropriate agent or mechanism to present the data to the user, or otherwise deal with the data in an appropriate manner. Ex: Content-Type: text/plain; charset=utf-8'
-    Host:
-      name: Host
-      in: header
-      required: true
-      schema:
-        type: string
-      description: 'The Host request header field specifies the internet host and port number of the resource being requested. Ex: Host: us-extract.api.smarty.com'
+      description: 'The match output strategy to be employed for this lookup. See more here: https://www.smarty.com/docs/cloud/us-street-api#match. Default: strict'
   schemas:
     '200':
       title: Successful response
@@ -185,31 +188,18 @@ components:
           example: 49
         api_output:
           type: array
-          description: The response from the US Street API
+          description: The actual response from the US Street API
           items:
             $ref: '#/components/schemas/APIOutput'
     APIOutput:
       title: APIOutput
       type: object
       properties:
-        input_id:
-          type: string
-          maxLength: 36
-          description: Any unique identifier that you use to reference the input address; the output will be identical to the input.
-        input_index:
-          type: integer
-          description: |-
-            The order in which this address was submitted with the others
-            (0 if alone)
         candidate_index:
           type: integer
           description: |-
             An input address can match multiple valid addresses. This ties the candidates to the input index. 
             (e.g., "1 Rosedale Street Baltimore Maryland" will return multiple candidates.)
-        addressee:
-          type: string
-          description: 'The name of the person or company at this address. This value is taken directly from the addressee input field. Very rarely, this field might be filled automatically based on the USPS address record.'
-          maxLength: 50
         delivery_line_1:
           type: string
           description: |-
@@ -227,10 +217,6 @@ components:
             PMB designator
             PMB number
           maxLength: 50
-        delivery_line_2:
-          type: string
-          description: 'The second delivery line (if needed). It is common for this field to remain empty, but it may contain a private mailbox number.'
-          maxLength: 50
         last_line:
           type: string
           description: 'City, state, and ZIP Code combined'
@@ -239,10 +225,6 @@ components:
           type: string
           description: '12-digit POSTNET™ barcode; consists of 5-digit ZIP Code, 4-digit add-on code, 2-digit delivery point, and 1-digit check digit.'
           maxLength: 12
-        smarty_key:
-          type: string
-          description: "Smarty's unique identifier for an address. This identifier will only be displayed when an address is submitted with the match parameter set to 'enhanced,' with an appropriate product subscription."
-          maxLength: 10
         components:
           $ref: '#/components/schemas/ComponentsObject'
         metadata:
@@ -254,10 +236,6 @@ components:
       type: object
       description: Object representing the different components of a verified address
       properties:
-        urbanization:
-          type: string
-          maxLength: 64
-          description: 'The neighborhood, or city subdivision; used with Puerto Rican addresses'
         primary_number:
           type: string
           description: 'The house, PO Box, or building number'
@@ -266,53 +244,13 @@ components:
           type: string
           description: The name of the street
           maxLength: 64
-        street_predirection:
-          type: string
-          maxLength: 16
-          description: 'Directional information before a street name (N, SW, etc.)'
-        street_postdirection:
-          type: string
-          description: 'Directional information after a street name (N, SW, etc.)'
-          maxLength: 16
         street_suffix:
           type: string
           description: 'Abbreviated value describing the street (St, Ave, Blvd, etc.)'
           maxLength: 16
-        secondary_number:
-          type: string
-          description: 'Apartment or suite number, if any'
-          maxLength: 32
-        secondary_designator:
-          type: string
-          description: 'Describes location within a complex/building (Ste, Apt, etc.)'
-          maxLength: 16
-        extra_secondary_number:
-          type: string
-          description: |-
-            Descriptive information about the location of a building within a campus 
-            (e.g., E-5 in "5619 Loop 1604, Bldg E-5, Ste. 101 San Antonio TX")
-          maxLength: 32
-        extra_secondary_designator:
-          type: string
-          description: |-
-            Description of the location type within a campus 
-            (e.g., Bldg, Unit, Lot, etc.)
-          maxLength: 16
-        pmb_designator:
-          type: string
-          description: 'The private mailbox unit designator, assigned by a CMRA'
-          maxLength: 16
-        pmb_number:
-          type: string
-          description: 'The private mailbox number, assigned by a CMRA'
-          maxLength: 16
         city_name:
           type: string
           description: 'The USPS-preferred city name for this particular address, or an acceptable alternate if provided by the user'
-          maxLength: 64
-        default_city_name:
-          type: string
-          description: The default city name for this 5-digit ZIP Code
           maxLength: 64
         state_abbreviation:
           type: string
@@ -375,14 +313,6 @@ components:
           type: string
           maxLength: 5
           description: The name of the county in which the address is located
-        ews_match:
-          type: string
-          maxLength: 5
-          description: |-
-            Early warning system flag; a positive result indicates the street of the address is not yet ready for mail delivery and that the address will soon be added to the master ZIP+4 file in the coming weeks or months. This commonly occurs for new streets or streets undergoing a name change. 
-
-            true — The address was flagged by EWS, preventing a ZIP+4 match.
-            [blank] — Address was not flagged by EWS.
         carrier_route:
           type: string
           maxLength: 4
@@ -401,14 +331,6 @@ components:
           type: string
           maxLength: 2
           description: 'The congressional district to which the address belongs. Output will be two digits from 01 - 53 or "AL." "AL" means that the entire state (or territory) is covered by a single congressional district. These include Alaska, Delaware, Montana, North Dakota, South Dakota, Vermont, Wyoming, Washington DC, Virgin Islands, and other territories.'
-        building_default_indicator:
-          type: string
-          maxLength: 1
-          description: |-
-            Indicates whether the address is the "default" address for a building; for example, the main lobby 
-
-            Y — Yes
-            N — No
         rdi:
           type: string
           maxLength: 12
@@ -439,9 +361,6 @@ components:
         longitude:
           type: number
           description: 'The vertical component used for geographic positioning. It is the angle between 0° (the Prime Meridian) and ±180° (westward or eastward). It is the second number in an ordered pair of (latitude, longitude). A negative number indicates a location west of Greenwich, England; a positive number east. Combining lat/long values enables you to pinpoint addresses on a map.'
-        coordinate_license:
-          type: integer
-          description: The license ID for the geographic coordinate returned. See the licensing table below for more details.
         precision:
           type: string
           maxLength: 18
@@ -571,15 +490,6 @@ components:
             Y — Address is vacant.
             N — Address is not vacant.
             [blank] — Address was not submitted for vacancy verification.
-        dpv_no_stat:
-          type: string
-          maxLength: 1
-          description: |-
-            Indicates that a delivery point is listed as "no-stat" by the USPS. Technically, that means the USPS is temporarily declaring the address undeliverable. In practice, however, the USPS is often several months behind in removing addresses from the "no-stat" list, so only rely on this data point if you are fully aware of its weaknesses and limitations. 
-
-            Y — USPS lists the address as "no-stat."
-            N — USPS does not list the address as "no-stat."
-            [blank] — Address was not submitted for "no-stat" verification.
         active:
           type: string
           maxLength: 1
@@ -588,49 +498,6 @@ components:
           type: string
           maxLength: 12
           description: 'Indicates which changes were made to the input address. Footnotes are delimited by a # character. See the footnotes table below for details.'
-        lacslink_code:
-          type: string
-          maxLength: 2
-          description: |-
-            The reason for the LACSLink indication that was given (below) 
-
-            A — Match: Address provided. LACSLink record match was found, and a converted address was provided.
-            00 — No Match. No converted address. No soup for you!
-            09 — Match: No new address. LACSLink matched an input address to an old address which is a "high-rise default" address; no new address was provided.
-            14 — Match: No conversion. Found a LACSLink record, but couldn't convert the data to a deliverable address.
-            92 — Match: Dropped secondary number. LACSLink record was matched after dropping the secondary number from input.
-            [blank] — No LACSLink lookup attempted.
-        lacslink_indicator:
-          type: string
-          maxLength: 1
-          description: |-
-            Indicates whether there is an address match in the LACSLink database. 
-
-            Y — LACS record match; a new address could be furnished because the input record matched a record in the master file.
-            S — LACS record - secondary number dropped; the record is a ZIP+4 street level or high-rise match. The input record matched a master file record, but the input address had a secondary number and the master file record did not.
-            N — No match; a new address could not be furnished; the input record could not be matched to a record in the master file.
-            F — False positive; a false positive record was detected.
-            [blank] — No LACSLink lookup attempted.
-        suitelink_match:
-          type: string
-          maxLength: 5
-          description: |-
-            Indicates a match (or not) to the USPS SuiteLink data. SuiteLink attempts to provide secondary information such as "suite" or "apartment" whenever there is a match based on address and company name. 
-
-            true — There was a SuiteLink match and the result is provided.
-            false — There was no SuiteLink match.
-        enhanced_match:
-          type: string
-          maxLength: 64
-          description: |-
-            When an address is submitted with the match parameter set to "enhanced," this field will contain additional information about the result. Multiple values may be present, separated by commas. Additional values will be added from time to time. The current possible values are:
-              
-              none — No address match was found.
-              non-postal-match — A match was found within additional, non-postal address data.
-              postal-match — A match was found within postal address data.
-              missing-secondary — The address should have a secondary (e.g., apartment), but none was found in the input.
-              unknown-secondary — The provided secondary information did not match a known secondary within the address data.
-              ignored-input — The provided input contained information that was not used for a match.
       description: Object representing the different metadata of a verified address
   securitySchemes:
     auth_id:

--- a/us-reverse-geo.yaml
+++ b/us-reverse-geo.yaml
@@ -58,13 +58,19 @@ paths:
           in: query
           name: latitude
           required: true
-          description: latitudinal coordinate to begin search
+          description: 'Latitude portion of the coordinate. The latitude must be specified as a decimal between -90.0 and 90.0'
         - schema:
             type: number
           in: query
           name: longitude
           required: true
-          description: longitudinal coordinate to begin search
+          description: 'Longitude portion of the coordinate. The longitude must be specified as a decimal between -180.0 and 180.0'
+        - schema:
+            type: string
+          in: query
+          name: source
+          required: false
+          description: 'Includes all results from alternate data sources. Allowed values are: all - will include non-postal addresses in the results; postal - will limit the results to postal addresses only. If this parameter is used, an additional field named soruce will be returned for each result. Default: postal'
       description: This api runs Smarty's reverse geocoding algorithms to convert latitudinal and longitudinal coordinates into the closest street addresses at lightning speed! Enter your auth-id and auth-token or just a Smarty embedded-key along with your coordinates and you are off!
       security:
         - auth-id: [ ]
@@ -73,37 +79,27 @@ paths:
     parameters: [ ]
 components:
   schemas:
-    Address:
-      type: object
-      examples:
-        - street: 2335 S State St
-          city: Provo
-          state_abbreviation: UT
-          zipcode: '84606'
-      title: Address
-      description: Object containing basic address information
-      properties:
-        street:
-          type: string
-          maxLength: 64
-          description: varchar(64) The street name of this address.
-        city:
-          type: string
-          maxLength: 64
-          description: varchar(64) The city name of this address.
-        state_abbreviation:
-          type: string
-          maxLength: 2
-          description: varchar(2) The state abbreviation of this address.
-        zipcode:
-          type: string
-          maxLength: 5
-          description: varchar(5) The 5-digit ZIP Code of this address.
-      required:
-        - Street
-        - city
-        - state_abbreviation
-        - zipcode
+    Result:
+      title: Result
+      type: array
+      maxLength: 10
+      items:
+        type: object
+        properties:
+          coordinate:
+            $ref: '#/components/schemas/Coordinate'
+            description: Coordinate object containing basic coordinate information
+          distance:
+            type: number
+            examples:
+              - 34.95276
+            description: The distance in meters of this address to the input latitude/longitude values.
+          address:
+            $ref: '#/components/schemas/Address'
+            description: Address object containing basic address information
+        required:
+          - address
+          - coordinate
     Coordinate:
       type: object
       examples:
@@ -154,27 +150,46 @@ components:
         - latitude
         - longitude
         - license
-    Result:
-      title: Result
-      type: array
-      maxLength: 10
-      items:
-        type: object
-        properties:
-          coordinate:
-            $ref: '#/components/schemas/Coordinate'
-            description: Coordinate object containing basic coordinate information
-          distance:
-            type: number
-            examples:
-              - 34.95276
-            description: The distance in meters of this address to the input latitude/longitude values.
-          address:
-            $ref: '#/components/schemas/Address'
-            description: Address object containing basic address information
-        required:
-          - address
-          - coordinate
+    Address:
+      type: object
+      examples:
+        - street: 1476 Sandhill Rd
+          city: Orem
+          state_abbreviation: UT
+          zipcode: '84058'
+      title: Address
+      description: Object containing basic address information
+      properties:
+        street:
+          type: string
+          maxLength: 64
+          description: varchar(64) The street name of this address.
+        city:
+          type: string
+          maxLength: 64
+          description: varchar(64) The city name of this address.
+        state_abbreviation:
+          type: string
+          maxLength: 2
+          description: varchar(2) The state abbreviation of this address.
+        zipcode:
+          type: string
+          maxLength: 5
+          description: varchar(5) The 5-digit ZIP Code of this address.
+        source:
+          type: string
+          maxLength: 6
+          description: This field is only returned if the request contained the source parameter. When it is returned, it indicates the data source for this address. Postal - the address is deliverable by the USPS. Other - the address was obtained from an alternate source (non-postal).
+        smarty_key:
+          type: string
+          maxLength: 10
+          description: Smarty's unique identifier for an address
+      required:
+        - Street
+        - city
+        - state_abbreviation
+        - zipcode
+        - smarty_key
   securitySchemes:
     auth-id:
       name: auth-id

--- a/us-street-api.yaml
+++ b/us-street-api.yaml
@@ -80,6 +80,7 @@ paths:
         - $ref: '#/components/parameters/match'
         - $ref: '#/components/parameters/format'
         - $ref: '#/components/parameters/county_source'
+        - $ref: '#/components/parameters/features'
     post:
       summary: Multiple Address Validation
       tags:
@@ -92,6 +93,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessfulResponse'
+        '400':
+          description: 'Bad Request (Malformed Payload): A GET request lacked a street field, or the request body of a POST request contained malformed JSON. (example: submitting an integer value in the ZIP Code field when a string is expected)'
+        '401':
+          description: 'Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.'
+        '402':
+          description: 'Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.'
+        '413':
+          description: 'Request Entity too large: The maxmimum size for a request body to this API is 32K (32,768 bytes).'
+        '422':
+          description: 'Unprocessable entity: A POST request lacked a street field.'
+        '429':
+          description: 'Too Many Requests: When using public embedded key authentication, we restrict the number of requests coming from a given source over too short of a time. If you use embedded key authentication, you can avoid this error by adding your IP address as an authorized host for the embedded key in question.'
       description: | 
         A POST request allows a larger volume of data (MAX: 100 addresses or 32K per request) to be sent in the HTTP Request Body. In this case, the data should be encoded as a JSON array where each element in the array is a JSON object with field names identical to those in the field listing below. Here's a sample request with two addresses being sent (line breaks added for readability):
         ```bash
@@ -224,6 +237,10 @@ components:
       description: 'The authoritative source to be used for the county information of the address. Valid values are: postal  The API will return county information based on the postal delivery information of the address. This is the default option. geographic  The API will return county information based on the physical location of the address.'
       schema:
         type: string
+    features:  
+      description: 'Component Analysis is available in the US Address Verification 42-day Free Trial and certain custom plans. If you have a subscription that allows for component analysis details, to return the component analysis details include the features parameters as features=components-analysis.'
+      schema:
+        type: string
   schemas:
     Root:
       title: Response Component
@@ -287,6 +304,8 @@ components:
           $ref: '#/components/schemas/Metadata'
         analysis:
           $ref: '#/components/schemas/Analysis'
+        component-analysis:
+          $ref: '#/components/schemas/Component-Analysis'
     Components:
       title: Components
       type: object
@@ -585,6 +604,8 @@ components:
 
             Here are some common combinations:
             AABB - ZIP, state, city, street name, and primary number match.
+            AABBCC - ZIP, state, city, street name, and primary number match, but secondary does not. A secondary is NOT required for delivery.
+            AAC1 - ZIP, state, city, street name, and primary number match, but secondary does not. A secondary is required for delivery.
             AAM1 - ZIP, state, city, and street name match, but the primary number is missing.
             AAM3 - ZIP, state, city, and street name match, but the primary number is invalid.
             AAN1 - ZIP, state, city, street name, and primary number match, but there is secondary information such as apartment or suite that would be helpful.
@@ -668,6 +689,27 @@ components:
             unknown-secondary — The provided secondary information did not match a known secondary within the address data.
             ignored-input — The provided input contained information that was not used for a match.
       description: Object representing the different metadata of a verified address
+    Component-Analysis:
+      title: Component-Analysis
+      type: object
+      properties:
+        status:
+          type: string
+          description: |-
+            Indicates the match classification of the given component.
+            confirmed - This indicates taht the component is valid in the returned response.
+            unconfirmed - This indicates taht the component was derived from the input, but is not a confirmed component of a fully matched address. For example, a match to a root address may contain an unconfirmed secondary. In this case, the secondary number and designator will show "unconfirmed" as their status.
+            missing - This indicates that the component is required for a fully validated response. This is most common in cases where secondary address components are required for delivery.
+        change:
+          type: string
+          description: |-
+            Indicates the change that Smarty performed on the input component.
+            abbreviation - The component was changed according to standard abbreviation rules. This is common in cases like direcitonals (NORTH -> N) and suffixes (STREET -> ST).
+            replaced - The input had a valid option for this component, but it was replaced for the correct component information. This value is only possible in components where there is a set number of valid options, such as: street_predirection, street_suffix, street_postdirection, secondary_designator, zipcode.
+            spelling - The input was corrected according to spelling rules.
+            added - The component was added as a result.
+            alias - Based on authoritative sources, the preferred value is returned.
+      description: When the features=component-analysis parameter is specified, component analysis details will be returned and can be applied to multiple addresses.
     RequestObject:
       type: object
       x-examples:
@@ -762,6 +804,9 @@ components:
             The authoritative source to be used for the county information of the address. Valid values are:
             postal  The API will return county information based on the postal delivery information of the address. This is the default option.
             geographic  The API will return county information based on the physical location of the address.
+        features:
+          type: string
+            description: Component Analysis is available in the US Address Verification 42-day Free Trial and certain custom plans. If you have a subscription that allows for component analysis details, to return the component analysis details include the features parameters as features=components-analysis. Component analysis details can be applied to multiple addresses.
       description: |-
         Each address submitted must have non-blank values for one of the following field combinations to be eligible for a positive address match:
 


### PR DESCRIPTION
The main changes are as follows:
- Property/principal and property/financial have been combined into /property and now use a features input to distinguish the two
- GeoReference is now named Census Block and Tract Data (though the endpoint is still called geo-reference)
- Risk was removed entirely